### PR TITLE
Change the package name to pdl-compiler and the default binary to pdlc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Cargo.lock
+scripts/pdl/__pycache__/
 target/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,23 @@
 [package]
-name = "pdl"
+name = "pdl-compiler"
 version = "0.1.0"
 edition = "2021"
-default-run = "pdl"
+description = "Parser and serializer generator for protocol binary packets"
+repository = "https://github.com/google/pdl/"
+license-file = "LICENSE"
+readme = "README.md"
+keywords = ["pdl", "parser", "serializer", "grammar"]
+authors = [
+    "Henri Chataing <henrichataing@google.com>",
+    "David de Jesus Duarte <licorne@google.com>",
+    "Martin Geisler <mgeisler@google.com>"
+]
+categories = ["parsing"]
+default-run = "pdlc"
+
+[[bin]]
+name = "pdlc"
+path = "src/main.rs"
 
 [workspace]
 


### PR DESCRIPTION
The crate name pdl is already taken on crates.io.