### PR TITLE
Trigger builds when PRs are synchronized

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: build
 
 on:
+  - pull_request
   - push
 
 env:


### PR DESCRIPTION
The `push` trigger is enough when people open PRs via branches in this repository. However, since we hope to get contributions via forks, we need to trigger on `pull_request` synchronization too.