### PR TITLE
Allow build workflow to be run via `workflow_dispatch`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: build
 on:
   - pull_request
   - push
+  - workflow_dispatch
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This should make it easy to trigger builds via the web interface, see the [documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch).