### PR TITLE
Restrict pest and pest_derive versions to 2.5.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ default = ["serde"]
 [dependencies]
 codespan-reporting = "0.11.1"
 heck = "0.4.0"
-pest = "2.5.5"
-pest_derive = "2.5.5"
+pest = "=2.5.5"
+pest_derive = "=2.5.5"
 proc-macro2 = "1.0.46"
 quote = "1.0.21"
 serde_json = "1.0.86"


### PR DESCRIPTION
Limited by the crate version in AOSP (2.5.5)