### PR TITLE
Add fuzz testing targets

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "pdl-compiler-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.pdl-compiler]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "backends_json_generate"
+path = "fuzz_targets/backends_json_generate.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "backends_rust_generate"
+path = "fuzz_targets/backends_rust_generate.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/backends_json_generate.rs
+++ b/fuzz/fuzz_targets/backends_json_generate.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use pdl_compiler::{ast, backends, parser};
+
+// Fuzz pdl_compiler::backends::json::generate.
+fuzz_target!(|source: String| {
+    let mut sources = ast::SourceDatabase::new();
+    let Ok(file) = parser::parse_inline(&mut sources, String::from("input.pdl"), source) else {
+        return;
+    };
+    let _ = backends::json::generate(&file);
+});

--- a/fuzz/fuzz_targets/backends_rust_generate.rs
+++ b/fuzz/fuzz_targets/backends_rust_generate.rs
@@ -1,0 +1,16 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use pdl_compiler::{analyzer, ast, backends, parser};
+
+// Fuzz pdl_compiler::backends::rust::generate.
+fuzz_target!(|source: String| {
+    let mut sources = ast::SourceDatabase::new();
+    let Ok(file) = parser::parse_inline(&mut sources, String::from("input.pdl"), source) else {
+        return;
+    };
+    let Ok(analyzed_file) = analyzer::analyze(&file) else {
+        return
+    };
+    let _ = backends::rust::generate(&sources, &analyzed_file);
+});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,24 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! PDL parser and analyzer.
+
+pub mod analyzer;
+pub mod ast;
+pub mod backends;
+pub mod lint;
+pub mod parser;
+#[cfg(test)]
+pub mod test_utils;
+pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,14 +17,7 @@
 use argh::FromArgs;
 use codespan_reporting::term::{self, termcolor};
 
-mod analyzer;
-mod ast;
-mod backends;
-mod lint;
-mod parser;
-#[cfg(test)]
-mod test_utils;
-mod utils;
+use pdl_compiler::{analyzer, ast, backends, parser};
 
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
This PR adds fuzz targets for the JSON and Rust backends.

The JSON backend is very small and basically glues existing libraries together. As such, it's the one that should "just work" and so far, it seems solid.

The Rust backend is full of our own code and the fuzzer there immediately found two small bugs: #32 and #33.

We can work on enabling the fuzzer when they're a bit more stable.