### PR TITLE
Update CXX runtime and generator

### DIFF
--- a/scripts/generate_cxx_backend.py
+++ b/scripts/generate_cxx_backend.py
@@ -1003,7 +1003,7 @@ def generate_packet_view_field_accessors(packet: ast.PacketDeclaration) -> List[
             accessors.append(
                 dedent("""\
                 std::vector<uint8_t> GetPayload() const {
-                    ASSERT(valid_);
+                    _ASSERT_VALID(valid_);
                     return payload_.bytes();
                 }
 
@@ -1015,7 +1015,7 @@ def generate_packet_view_field_accessors(packet: ast.PacketDeclaration) -> List[
             accessors.append(
                 dedent("""\
                 {array_type} Get{accessor_name}() const {{
-                    ASSERT(valid_);
+                    _ASSERT_VALID(valid_);
                     {accessor}
                 }}
 
@@ -1028,7 +1028,7 @@ def generate_packet_view_field_accessors(packet: ast.PacketDeclaration) -> List[
             accessors.append(
                 dedent("""\
                 {field_type} Get{accessor_name}() const {{
-                    ASSERT(valid_);
+                    _ASSERT_VALID(valid_);
                     return {member_name}_;
                 }}
 
@@ -1039,7 +1039,7 @@ def generate_packet_view_field_accessors(packet: ast.PacketDeclaration) -> List[
             accessors.append(
                 dedent("""\
                 {field_type}{field_qualifier} Get{accessor_name}() const {{
-                    ASSERT(valid_);
+                    _ASSERT_VALID(valid_);
                     return {member_name}_;
                 }}
 
@@ -1542,10 +1542,12 @@ def run(input: argparse.FileType, output: argparse.FileType, namespace: Optional
         {include_header}
         {using_namespace}
 
-        #ifndef ASSERT
+        #ifdef ASSERT
+        #define _ASSERT_VALID ASSERT
+        #else
         #include <cassert>
-        #define ASSERT assert
-        #endif  // !ASSERT
+        #define _ASSERT_VALID assert
+        #endif  // ASSERT
 
         {open_namespace}
         """).format(input_name=input.name,

--- a/scripts/generate_cxx_backend_tests.py
+++ b/scripts/generate_cxx_backend_tests.py
@@ -269,7 +269,7 @@ def generate_packet_serializer_test(serializer_test_suite: str, packet: ast.Pack
                 }};
                 {intermediate_declarations}
                 {child_packet_id}Builder packet = {built_packet};
-                ASSERT_EQ(packet.pdl::packet::Builder::Serialize(), expected_output);
+                ASSERT_EQ(packet.SerializeToBytes(), expected_output);
             }}
             """).format(serializer_test_suite=serializer_test_suite,
                         packet_id=packet.id,

--- a/scripts/packet_runtime.h
+++ b/scripts/packet_runtime.h
@@ -150,7 +150,7 @@ class Builder {
   }
 
   /// Helper method to serialize the packet to a byte vector.
-  virtual std::vector<uint8_t> Serialize() const {
+  virtual std::vector<uint8_t> SerializeToBytes() const {
     std::vector<uint8_t> output;
     Serialize(output);
     return output;


### PR DESCRIPTION
- Rename Serialize -> SerializeToBytes
  The compiler is unable to resolve to serialize
  because of its overloading virtual namesake

- Rename ASSERT -> _ASSERT_VALID to prevent
  clashes with definitions in external headers
