### PR TITLE
Remove the use of Arc<> in the generated rust code

### DIFF
--- a/src/backends/rust.rs
+++ b/src/backends/rust.rs
@@ -483,9 +483,9 @@ fn generate_packet_decl(
         }
 
         quote! {
-            let #parent_id_lower = Arc::new(#parent_data {
+            let #parent_id_lower = #parent_data {
                 #(#field: #value,)*
-            });
+            };
         }
     });
 
@@ -510,7 +510,7 @@ fn generate_packet_decl(
             #[derive(Debug, Clone, PartialEq, Eq)]
             #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
             pub enum #id_data_child {
-                #(#child(Arc<#child_data>),)*
+                #(#child(#child_data),)*
                 Payload(Bytes),
                 None,
             }
@@ -588,7 +588,7 @@ fn generate_packet_decl(
         pub struct #id_packet {
             #(
                 #[cfg_attr(feature = "serde", serde(flatten))]
-                #parent_lower_ids: Arc<#parent_data>,
+                #parent_lower_ids: #parent_data,
             )*
         }
 
@@ -637,12 +637,12 @@ fn generate_packet_decl(
 
             fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
                 let data = #top_level_data::parse_inner(&mut bytes)?;
-                Self::new(Arc::new(data))
+                Self::new(data)
             }
 
             #specialize
 
-            fn new(#top_level_id_lower: Arc<#top_level_data>) -> Result<Self> {
+            fn new(#top_level_id_lower: #top_level_data) -> Result<Self> {
                 #(
                     let #parent_shifted_lower_ids = match &#parent_lower_ids.child {
                         #parent_data_child::#parent_shifted_ids(value) => value.clone(),
@@ -656,7 +656,7 @@ fn generate_packet_decl(
             }
 
             #(pub fn #all_field_getter_names(&self) -> #all_field_borrows #all_field_types {
-                #all_field_borrows #all_field_self_field.as_ref().#all_field_names
+                #all_field_borrows #all_field_self_field.#all_field_names
             })*
 
             #get_payload

--- a/src/backends/rust/parser.rs
+++ b/src/backends/rust/parser.rs
@@ -702,7 +702,7 @@ impl<'a> FieldParser<'a> {
                     let mut cell = Cell::new(payload);
                     let child_data = #child_ids_data::parse_inner(&mut cell #child_parse_args)?;
                     // TODO(mgeisler): communicate back to user if !cell.get().is_empty()?
-                    #packet_data_child::#child_ids(Arc::new(child_data))
+                    #packet_data_child::#child_ids(child_data)
                 }),*
                 _ if !payload.is_empty() => {
                     #packet_data_child::Payload(Bytes::copy_from_slice(payload))

--- a/src/backends/rust/preamble.rs
+++ b/src/backends/rust/preamble.rs
@@ -55,7 +55,6 @@ pub fn generate(path: &Path) -> proc_macro2::TokenStream {
         use std::convert::{TryFrom, TryInto};
         use std::cell::Cell;
         use std::fmt;
-        use std::sync::Arc;
         use thiserror::Error;
 
         type Result<T> = std::result::Result<T, Error>;

--- a/tests/generated/custom_field_declaration_big_endian.rs
+++ b/tests/generated/custom_field_declaration_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values

--- a/tests/generated/custom_field_declaration_little_endian.rs
+++ b/tests/generated/custom_field_declaration_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values

--- a/tests/generated/enum_declaration_big_endian.rs
+++ b/tests/generated/enum_declaration_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values

--- a/tests/generated/enum_declaration_little_endian.rs
+++ b/tests/generated/enum_declaration_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values

--- a/tests/generated/packet_decl_24bit_enum_array_big_endian.rs
+++ b/tests/generated/packet_decl_24bit_enum_array_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -99,7 +98,7 @@ pub struct BarData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    bar: Arc<BarData>,
+    bar: BarData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -178,13 +177,13 @@ impl Bar {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = BarData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(bar: Arc<BarData>) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> &[Foo; 5] {
-        &self.bar.as_ref().x
+        &self.bar.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.bar.write_to(buffer)
@@ -195,7 +194,7 @@ impl Bar {
 }
 impl BarBuilder {
     pub fn build(self) -> Bar {
-        let bar = Arc::new(BarData { x: self.x });
+        let bar = BarData { x: self.x };
         Bar::new(bar).unwrap()
     }
 }

--- a/tests/generated/packet_decl_24bit_enum_array_little_endian.rs
+++ b/tests/generated/packet_decl_24bit_enum_array_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -99,7 +98,7 @@ pub struct BarData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    bar: Arc<BarData>,
+    bar: BarData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -178,13 +177,13 @@ impl Bar {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = BarData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(bar: Arc<BarData>) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> &[Foo; 5] {
-        &self.bar.as_ref().x
+        &self.bar.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.bar.write_to(buffer)
@@ -195,7 +194,7 @@ impl Bar {
 }
 impl BarBuilder {
     pub fn build(self) -> Bar {
-        let bar = Arc::new(BarData { x: self.x });
+        let bar = BarData { x: self.x };
         Bar::new(bar).unwrap()
     }
 }

--- a/tests/generated/packet_decl_24bit_enum_big_endian.rs
+++ b/tests/generated/packet_decl_24bit_enum_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -99,7 +98,7 @@ pub struct BarData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    bar: Arc<BarData>,
+    bar: BarData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -170,13 +169,13 @@ impl Bar {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = BarData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(bar: Arc<BarData>) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> Foo {
-        self.bar.as_ref().x
+        self.bar.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.bar.write_to(buffer)
@@ -187,7 +186,7 @@ impl Bar {
 }
 impl BarBuilder {
     pub fn build(self) -> Bar {
-        let bar = Arc::new(BarData { x: self.x });
+        let bar = BarData { x: self.x };
         Bar::new(bar).unwrap()
     }
 }

--- a/tests/generated/packet_decl_24bit_enum_little_endian.rs
+++ b/tests/generated/packet_decl_24bit_enum_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -99,7 +98,7 @@ pub struct BarData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    bar: Arc<BarData>,
+    bar: BarData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -170,13 +169,13 @@ impl Bar {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = BarData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(bar: Arc<BarData>) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> Foo {
-        self.bar.as_ref().x
+        self.bar.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.bar.write_to(buffer)
@@ -187,7 +186,7 @@ impl Bar {
 }
 impl BarBuilder {
     pub fn build(self) -> Bar {
-        let bar = Arc::new(BarData { x: self.x });
+        let bar = BarData { x: self.x };
         Bar::new(bar).unwrap()
     }
 }

--- a/tests/generated/packet_decl_24bit_scalar_array_big_endian.rs
+++ b/tests/generated/packet_decl_24bit_scalar_array_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -53,7 +52,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -124,13 +123,13 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> &[u32; 5] {
-        &self.foo.as_ref().x
+        &self.foo.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -141,7 +140,7 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData { x: self.x });
+        let foo = FooData { x: self.x };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_24bit_scalar_array_little_endian.rs
+++ b/tests/generated/packet_decl_24bit_scalar_array_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -53,7 +52,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -124,13 +123,13 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> &[u32; 5] {
-        &self.foo.as_ref().x
+        &self.foo.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -141,7 +140,7 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData { x: self.x });
+        let foo = FooData { x: self.x };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_24bit_scalar_big_endian.rs
+++ b/tests/generated/packet_decl_24bit_scalar_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -53,7 +52,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -121,13 +120,13 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> u32 {
-        self.foo.as_ref().x
+        self.foo.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -138,7 +137,7 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData { x: self.x });
+        let foo = FooData { x: self.x };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_24bit_scalar_little_endian.rs
+++ b/tests/generated/packet_decl_24bit_scalar_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -53,7 +52,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -121,13 +120,13 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> u32 {
-        self.foo.as_ref().x
+        self.foo.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -138,7 +137,7 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData { x: self.x });
+        let foo = FooData { x: self.x };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_64bit_enum_array_big_endian.rs
+++ b/tests/generated/packet_decl_64bit_enum_array_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -84,7 +83,7 @@ pub struct BarData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    bar: Arc<BarData>,
+    bar: BarData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -163,13 +162,13 @@ impl Bar {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = BarData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(bar: Arc<BarData>) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> &[Foo; 7] {
-        &self.bar.as_ref().x
+        &self.bar.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.bar.write_to(buffer)
@@ -180,7 +179,7 @@ impl Bar {
 }
 impl BarBuilder {
     pub fn build(self) -> Bar {
-        let bar = Arc::new(BarData { x: self.x });
+        let bar = BarData { x: self.x };
         Bar::new(bar).unwrap()
     }
 }

--- a/tests/generated/packet_decl_64bit_enum_array_little_endian.rs
+++ b/tests/generated/packet_decl_64bit_enum_array_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -84,7 +83,7 @@ pub struct BarData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    bar: Arc<BarData>,
+    bar: BarData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -163,13 +162,13 @@ impl Bar {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = BarData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(bar: Arc<BarData>) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> &[Foo; 7] {
-        &self.bar.as_ref().x
+        &self.bar.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.bar.write_to(buffer)
@@ -180,7 +179,7 @@ impl Bar {
 }
 impl BarBuilder {
     pub fn build(self) -> Bar {
-        let bar = Arc::new(BarData { x: self.x });
+        let bar = BarData { x: self.x };
         Bar::new(bar).unwrap()
     }
 }

--- a/tests/generated/packet_decl_64bit_enum_big_endian.rs
+++ b/tests/generated/packet_decl_64bit_enum_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -84,7 +83,7 @@ pub struct BarData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    bar: Arc<BarData>,
+    bar: BarData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -155,13 +154,13 @@ impl Bar {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = BarData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(bar: Arc<BarData>) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> Foo {
-        self.bar.as_ref().x
+        self.bar.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.bar.write_to(buffer)
@@ -172,7 +171,7 @@ impl Bar {
 }
 impl BarBuilder {
     pub fn build(self) -> Bar {
-        let bar = Arc::new(BarData { x: self.x });
+        let bar = BarData { x: self.x };
         Bar::new(bar).unwrap()
     }
 }

--- a/tests/generated/packet_decl_64bit_enum_little_endian.rs
+++ b/tests/generated/packet_decl_64bit_enum_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -84,7 +83,7 @@ pub struct BarData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    bar: Arc<BarData>,
+    bar: BarData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -155,13 +154,13 @@ impl Bar {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = BarData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(bar: Arc<BarData>) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> Foo {
-        self.bar.as_ref().x
+        self.bar.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.bar.write_to(buffer)
@@ -172,7 +171,7 @@ impl Bar {
 }
 impl BarBuilder {
     pub fn build(self) -> Bar {
-        let bar = Arc::new(BarData { x: self.x });
+        let bar = BarData { x: self.x };
         Bar::new(bar).unwrap()
     }
 }

--- a/tests/generated/packet_decl_64bit_scalar_array_big_endian.rs
+++ b/tests/generated/packet_decl_64bit_scalar_array_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -53,7 +52,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -124,13 +123,13 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> &[u64; 7] {
-        &self.foo.as_ref().x
+        &self.foo.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -141,7 +140,7 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData { x: self.x });
+        let foo = FooData { x: self.x };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_64bit_scalar_array_little_endian.rs
+++ b/tests/generated/packet_decl_64bit_scalar_array_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -53,7 +52,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -124,13 +123,13 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> &[u64; 7] {
-        &self.foo.as_ref().x
+        &self.foo.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -141,7 +140,7 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData { x: self.x });
+        let foo = FooData { x: self.x };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_64bit_scalar_big_endian.rs
+++ b/tests/generated/packet_decl_64bit_scalar_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -53,7 +52,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -118,13 +117,13 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> u64 {
-        self.foo.as_ref().x
+        self.foo.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -135,7 +134,7 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData { x: self.x });
+        let foo = FooData { x: self.x };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_64bit_scalar_little_endian.rs
+++ b/tests/generated/packet_decl_64bit_scalar_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -53,7 +52,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -118,13 +117,13 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> u64 {
-        self.foo.as_ref().x
+        self.foo.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -135,7 +134,7 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData { x: self.x });
+        let foo = FooData { x: self.x };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_8bit_enum_array_big_endian.rs
+++ b/tests/generated/packet_decl_8bit_enum_array_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -114,7 +113,7 @@ pub struct BarData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    bar: Arc<BarData>,
+    bar: BarData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -193,13 +192,13 @@ impl Bar {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = BarData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(bar: Arc<BarData>) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> &[Foo; 3] {
-        &self.bar.as_ref().x
+        &self.bar.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.bar.write_to(buffer)
@@ -210,7 +209,7 @@ impl Bar {
 }
 impl BarBuilder {
     pub fn build(self) -> Bar {
-        let bar = Arc::new(BarData { x: self.x });
+        let bar = BarData { x: self.x };
         Bar::new(bar).unwrap()
     }
 }

--- a/tests/generated/packet_decl_8bit_enum_array_little_endian.rs
+++ b/tests/generated/packet_decl_8bit_enum_array_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -114,7 +113,7 @@ pub struct BarData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    bar: Arc<BarData>,
+    bar: BarData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -193,13 +192,13 @@ impl Bar {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = BarData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(bar: Arc<BarData>) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> &[Foo; 3] {
-        &self.bar.as_ref().x
+        &self.bar.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.bar.write_to(buffer)
@@ -210,7 +209,7 @@ impl Bar {
 }
 impl BarBuilder {
     pub fn build(self) -> Bar {
-        let bar = Arc::new(BarData { x: self.x });
+        let bar = BarData { x: self.x };
         Bar::new(bar).unwrap()
     }
 }

--- a/tests/generated/packet_decl_8bit_enum_big_endian.rs
+++ b/tests/generated/packet_decl_8bit_enum_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -114,7 +113,7 @@ pub struct BarData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    bar: Arc<BarData>,
+    bar: BarData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -185,13 +184,13 @@ impl Bar {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = BarData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(bar: Arc<BarData>) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> Foo {
-        self.bar.as_ref().x
+        self.bar.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.bar.write_to(buffer)
@@ -202,7 +201,7 @@ impl Bar {
 }
 impl BarBuilder {
     pub fn build(self) -> Bar {
-        let bar = Arc::new(BarData { x: self.x });
+        let bar = BarData { x: self.x };
         Bar::new(bar).unwrap()
     }
 }

--- a/tests/generated/packet_decl_8bit_enum_little_endian.rs
+++ b/tests/generated/packet_decl_8bit_enum_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -114,7 +113,7 @@ pub struct BarData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    bar: Arc<BarData>,
+    bar: BarData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -185,13 +184,13 @@ impl Bar {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = BarData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(bar: Arc<BarData>) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> Foo {
-        self.bar.as_ref().x
+        self.bar.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.bar.write_to(buffer)
@@ -202,7 +201,7 @@ impl Bar {
 }
 impl BarBuilder {
     pub fn build(self) -> Bar {
-        let bar = Arc::new(BarData { x: self.x });
+        let bar = BarData { x: self.x };
         Bar::new(bar).unwrap()
     }
 }

--- a/tests/generated/packet_decl_8bit_scalar_array_big_endian.rs
+++ b/tests/generated/packet_decl_8bit_scalar_array_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -53,7 +52,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -124,13 +123,13 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> &[u8; 3] {
-        &self.foo.as_ref().x
+        &self.foo.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -141,7 +140,7 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData { x: self.x });
+        let foo = FooData { x: self.x };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_8bit_scalar_array_little_endian.rs
+++ b/tests/generated/packet_decl_8bit_scalar_array_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -53,7 +52,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -124,13 +123,13 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> &[u8; 3] {
-        &self.foo.as_ref().x
+        &self.foo.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -141,7 +140,7 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData { x: self.x });
+        let foo = FooData { x: self.x };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_8bit_scalar_big_endian.rs
+++ b/tests/generated/packet_decl_8bit_scalar_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -53,7 +52,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -118,13 +117,13 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> u8 {
-        self.foo.as_ref().x
+        self.foo.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -135,7 +134,7 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData { x: self.x });
+        let foo = FooData { x: self.x };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_8bit_scalar_little_endian.rs
+++ b/tests/generated/packet_decl_8bit_scalar_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -53,7 +52,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -118,13 +117,13 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> u8 {
-        self.foo.as_ref().x
+        self.foo.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -135,7 +134,7 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData { x: self.x });
+        let foo = FooData { x: self.x };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_array_dynamic_size_big_endian.rs
+++ b/tests/generated/packet_decl_array_dynamic_size_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -54,7 +53,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -155,16 +154,16 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_padding(&self) -> u8 {
-        self.foo.as_ref().padding
+        self.foo.padding
     }
     pub fn get_x(&self) -> &Vec<u32> {
-        &self.foo.as_ref().x
+        &self.foo.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -175,10 +174,10 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData {
+        let foo = FooData {
             padding: self.padding,
             x: self.x,
-        });
+        };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_array_dynamic_size_little_endian.rs
+++ b/tests/generated/packet_decl_array_dynamic_size_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -54,7 +53,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -155,16 +154,16 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_padding(&self) -> u8 {
-        self.foo.as_ref().padding
+        self.foo.padding
     }
     pub fn get_x(&self) -> &Vec<u32> {
-        &self.foo.as_ref().x
+        &self.foo.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -175,10 +174,10 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData {
+        let foo = FooData {
             padding: self.padding,
             x: self.x,
-        });
+        };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_array_unknown_element_width_dynamic_count_big_endian.rs
+++ b/tests/generated/packet_decl_array_unknown_element_width_dynamic_count_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -107,7 +106,7 @@ pub struct BarData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    bar: Arc<BarData>,
+    bar: BarData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -184,13 +183,13 @@ impl Bar {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = BarData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(bar: Arc<BarData>) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> &Vec<Foo> {
-        &self.bar.as_ref().x
+        &self.bar.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.bar.write_to(buffer)
@@ -201,7 +200,7 @@ impl Bar {
 }
 impl BarBuilder {
     pub fn build(self) -> Bar {
-        let bar = Arc::new(BarData { x: self.x });
+        let bar = BarData { x: self.x };
         Bar::new(bar).unwrap()
     }
 }

--- a/tests/generated/packet_decl_array_unknown_element_width_dynamic_count_little_endian.rs
+++ b/tests/generated/packet_decl_array_unknown_element_width_dynamic_count_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -107,7 +106,7 @@ pub struct BarData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    bar: Arc<BarData>,
+    bar: BarData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -184,13 +183,13 @@ impl Bar {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = BarData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(bar: Arc<BarData>) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> &Vec<Foo> {
-        &self.bar.as_ref().x
+        &self.bar.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.bar.write_to(buffer)
@@ -201,7 +200,7 @@ impl Bar {
 }
 impl BarBuilder {
     pub fn build(self) -> Bar {
-        let bar = Arc::new(BarData { x: self.x });
+        let bar = BarData { x: self.x };
         Bar::new(bar).unwrap()
     }
 }

--- a/tests/generated/packet_decl_array_unknown_element_width_dynamic_size_big_endian.rs
+++ b/tests/generated/packet_decl_array_unknown_element_width_dynamic_size_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -107,7 +106,7 @@ pub struct BarData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    bar: Arc<BarData>,
+    bar: BarData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -196,13 +195,13 @@ impl Bar {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = BarData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(bar: Arc<BarData>) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> &Vec<Foo> {
-        &self.bar.as_ref().x
+        &self.bar.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.bar.write_to(buffer)
@@ -213,7 +212,7 @@ impl Bar {
 }
 impl BarBuilder {
     pub fn build(self) -> Bar {
-        let bar = Arc::new(BarData { x: self.x });
+        let bar = BarData { x: self.x };
         Bar::new(bar).unwrap()
     }
 }

--- a/tests/generated/packet_decl_array_unknown_element_width_dynamic_size_little_endian.rs
+++ b/tests/generated/packet_decl_array_unknown_element_width_dynamic_size_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -107,7 +106,7 @@ pub struct BarData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    bar: Arc<BarData>,
+    bar: BarData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -196,13 +195,13 @@ impl Bar {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = BarData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(bar: Arc<BarData>) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> &Vec<Foo> {
-        &self.bar.as_ref().x
+        &self.bar.x
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.bar.write_to(buffer)
@@ -213,7 +212,7 @@ impl Bar {
 }
 impl BarBuilder {
     pub fn build(self) -> Bar {
-        let bar = Arc::new(BarData { x: self.x });
+        let bar = BarData { x: self.x };
         Bar::new(bar).unwrap()
     }
 }

--- a/tests/generated/packet_decl_array_with_padding_big_endian.rs
+++ b/tests/generated/packet_decl_array_with_padding_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -107,7 +106,7 @@ pub struct BarData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    bar: Arc<BarData>,
+    bar: BarData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -188,13 +187,13 @@ impl Bar {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = BarData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(bar: Arc<BarData>) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self> {
         Ok(Self { bar })
     }
     pub fn get_a(&self) -> &Vec<Foo> {
-        &self.bar.as_ref().a
+        &self.bar.a
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.bar.write_to(buffer)
@@ -205,7 +204,7 @@ impl Bar {
 }
 impl BarBuilder {
     pub fn build(self) -> Bar {
-        let bar = Arc::new(BarData { a: self.a });
+        let bar = BarData { a: self.a };
         Bar::new(bar).unwrap()
     }
 }

--- a/tests/generated/packet_decl_array_with_padding_little_endian.rs
+++ b/tests/generated/packet_decl_array_with_padding_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -107,7 +106,7 @@ pub struct BarData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    bar: Arc<BarData>,
+    bar: BarData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -188,13 +187,13 @@ impl Bar {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = BarData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(bar: Arc<BarData>) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self> {
         Ok(Self { bar })
     }
     pub fn get_a(&self) -> &Vec<Foo> {
-        &self.bar.as_ref().a
+        &self.bar.a
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.bar.write_to(buffer)
@@ -205,7 +204,7 @@ impl Bar {
 }
 impl BarBuilder {
     pub fn build(self) -> Bar {
-        let bar = Arc::new(BarData { a: self.a });
+        let bar = BarData { a: self.a };
         Bar::new(bar).unwrap()
     }
 }

--- a/tests/generated/packet_decl_complex_scalars_big_endian.rs
+++ b/tests/generated/packet_decl_complex_scalars_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -58,7 +57,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -168,28 +167,28 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_a(&self) -> u8 {
-        self.foo.as_ref().a
+        self.foo.a
     }
     pub fn get_b(&self) -> u8 {
-        self.foo.as_ref().b
+        self.foo.b
     }
     pub fn get_c(&self) -> u8 {
-        self.foo.as_ref().c
+        self.foo.c
     }
     pub fn get_d(&self) -> u32 {
-        self.foo.as_ref().d
+        self.foo.d
     }
     pub fn get_e(&self) -> u16 {
-        self.foo.as_ref().e
+        self.foo.e
     }
     pub fn get_f(&self) -> u8 {
-        self.foo.as_ref().f
+        self.foo.f
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -200,14 +199,14 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData {
+        let foo = FooData {
             a: self.a,
             b: self.b,
             c: self.c,
             d: self.d,
             e: self.e,
             f: self.f,
-        });
+        };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_complex_scalars_little_endian.rs
+++ b/tests/generated/packet_decl_complex_scalars_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -58,7 +57,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -168,28 +167,28 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_a(&self) -> u8 {
-        self.foo.as_ref().a
+        self.foo.a
     }
     pub fn get_b(&self) -> u8 {
-        self.foo.as_ref().b
+        self.foo.b
     }
     pub fn get_c(&self) -> u8 {
-        self.foo.as_ref().c
+        self.foo.c
     }
     pub fn get_d(&self) -> u32 {
-        self.foo.as_ref().d
+        self.foo.d
     }
     pub fn get_e(&self) -> u16 {
-        self.foo.as_ref().e
+        self.foo.e
     }
     pub fn get_f(&self) -> u8 {
-        self.foo.as_ref().f
+        self.foo.f
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -200,14 +199,14 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData {
+        let foo = FooData {
             a: self.a,
             b: self.b,
             c: self.c,
             d: self.d,
             e: self.e,
             f: self.f,
-        });
+        };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_custom_field_big_endian.rs
+++ b/tests/generated/packet_decl_custom_field_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -93,7 +92,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -154,16 +153,16 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_a(&self) -> Bar1 {
-        self.foo.as_ref().a
+        self.foo.a
     }
     pub fn get_b(&self) -> Bar2 {
-        self.foo.as_ref().b
+        self.foo.b
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -174,7 +173,7 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData { a: self.a, b: self.b });
+        let foo = FooData { a: self.a, b: self.b };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_custom_field_little_endian.rs
+++ b/tests/generated/packet_decl_custom_field_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -93,7 +92,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -154,16 +153,16 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_a(&self) -> Bar1 {
-        self.foo.as_ref().a
+        self.foo.a
     }
     pub fn get_b(&self) -> Bar2 {
-        self.foo.as_ref().b
+        self.foo.b
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -174,7 +173,7 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData { a: self.a, b: self.b });
+        let foo = FooData { a: self.a, b: self.b };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_empty_big_endian.rs
+++ b/tests/generated/packet_decl_empty_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -51,7 +50,7 @@ pub struct FooData {}
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -104,9 +103,9 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     fn write_to(&self, buffer: &mut BytesMut) {
@@ -118,7 +117,7 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData {});
+        let foo = FooData {};
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_empty_little_endian.rs
+++ b/tests/generated/packet_decl_empty_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -51,7 +50,7 @@ pub struct FooData {}
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -104,9 +103,9 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     fn write_to(&self, buffer: &mut BytesMut) {
@@ -118,7 +117,7 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData {});
+        let foo = FooData {};
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_fixed_enum_field_big_endian.rs
+++ b/tests/generated/packet_decl_fixed_enum_field_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -119,7 +118,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -198,13 +197,13 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_b(&self) -> u64 {
-        self.foo.as_ref().b
+        self.foo.b
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -215,7 +214,7 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData { b: self.b });
+        let foo = FooData { b: self.b };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_fixed_enum_field_little_endian.rs
+++ b/tests/generated/packet_decl_fixed_enum_field_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -119,7 +118,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -198,13 +197,13 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_b(&self) -> u64 {
-        self.foo.as_ref().b
+        self.foo.b
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -215,7 +214,7 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData { b: self.b });
+        let foo = FooData { b: self.b };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_fixed_scalar_field_big_endian.rs
+++ b/tests/generated/packet_decl_fixed_scalar_field_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -53,7 +52,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -132,13 +131,13 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_b(&self) -> u64 {
-        self.foo.as_ref().b
+        self.foo.b
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -149,7 +148,7 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData { b: self.b });
+        let foo = FooData { b: self.b };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_fixed_scalar_field_little_endian.rs
+++ b/tests/generated/packet_decl_fixed_scalar_field_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -53,7 +52,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -132,13 +131,13 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_b(&self) -> u64 {
-        self.foo.as_ref().b
+        self.foo.b
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -149,7 +148,7 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData { b: self.b });
+        let foo = FooData { b: self.b };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_mask_scalar_value_big_endian.rs
+++ b/tests/generated/packet_decl_mask_scalar_value_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -55,7 +54,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -135,19 +134,19 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_a(&self) -> u8 {
-        self.foo.as_ref().a
+        self.foo.a
     }
     pub fn get_b(&self) -> u32 {
-        self.foo.as_ref().b
+        self.foo.b
     }
     pub fn get_c(&self) -> u8 {
-        self.foo.as_ref().c
+        self.foo.c
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -158,11 +157,11 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData {
+        let foo = FooData {
             a: self.a,
             b: self.b,
             c: self.c,
-        });
+        };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_mask_scalar_value_little_endian.rs
+++ b/tests/generated/packet_decl_mask_scalar_value_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -55,7 +54,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -135,19 +134,19 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_a(&self) -> u8 {
-        self.foo.as_ref().a
+        self.foo.a
     }
     pub fn get_b(&self) -> u32 {
-        self.foo.as_ref().b
+        self.foo.b
     }
     pub fn get_c(&self) -> u8 {
-        self.foo.as_ref().c
+        self.foo.c
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -158,11 +157,11 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData {
+        let foo = FooData {
             a: self.a,
             b: self.b,
             c: self.c,
-        });
+        };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_mixed_scalars_enums_big_endian.rs
+++ b/tests/generated/packet_decl_mixed_scalars_enums_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -178,7 +177,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -270,22 +269,22 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_w(&self) -> u8 {
-        self.foo.as_ref().w
+        self.foo.w
     }
     pub fn get_x(&self) -> Enum7 {
-        self.foo.as_ref().x
+        self.foo.x
     }
     pub fn get_y(&self) -> u8 {
-        self.foo.as_ref().y
+        self.foo.y
     }
     pub fn get_z(&self) -> Enum9 {
-        self.foo.as_ref().z
+        self.foo.z
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -296,12 +295,12 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData {
+        let foo = FooData {
             w: self.w,
             x: self.x,
             y: self.y,
             z: self.z,
-        });
+        };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_mixed_scalars_enums_little_endian.rs
+++ b/tests/generated/packet_decl_mixed_scalars_enums_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -178,7 +177,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -270,22 +269,22 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_w(&self) -> u8 {
-        self.foo.as_ref().w
+        self.foo.w
     }
     pub fn get_x(&self) -> Enum7 {
-        self.foo.as_ref().x
+        self.foo.x
     }
     pub fn get_y(&self) -> u8 {
-        self.foo.as_ref().y
+        self.foo.y
     }
     pub fn get_z(&self) -> Enum9 {
-        self.foo.as_ref().z
+        self.foo.z
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -296,12 +295,12 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData {
+        let foo = FooData {
             w: self.w,
             x: self.x,
             y: self.y,
             z: self.z,
-        });
+        };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_payload_field_unknown_size_big_endian.rs
+++ b/tests/generated/packet_decl_payload_field_unknown_size_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -74,7 +73,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -155,7 +154,7 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
     pub fn specialize(&self) -> FooChild {
         match &self.foo.child {
@@ -163,11 +162,11 @@ impl Foo {
             FooDataChild::None => FooChild::None,
         }
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_a(&self) -> u32 {
-        self.foo.as_ref().a
+        self.foo.a
     }
     pub fn get_payload(&self) -> &[u8] {
         match &self.foo.child {
@@ -184,13 +183,13 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData {
+        let foo = FooData {
             a: self.a,
             child: match self.payload {
                 None => FooDataChild::None,
                 Some(bytes) => FooDataChild::Payload(bytes),
             },
-        });
+        };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_payload_field_unknown_size_little_endian.rs
+++ b/tests/generated/packet_decl_payload_field_unknown_size_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -74,7 +73,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -155,7 +154,7 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
     pub fn specialize(&self) -> FooChild {
         match &self.foo.child {
@@ -163,11 +162,11 @@ impl Foo {
             FooDataChild::None => FooChild::None,
         }
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_a(&self) -> u32 {
-        self.foo.as_ref().a
+        self.foo.a
     }
     pub fn get_payload(&self) -> &[u8] {
         match &self.foo.child {
@@ -184,13 +183,13 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData {
+        let foo = FooData {
             a: self.a,
             child: match self.payload {
                 None => FooDataChild::None,
                 Some(bytes) => FooDataChild::Payload(bytes),
             },
-        });
+        };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_payload_field_unknown_size_terminal_big_endian.rs
+++ b/tests/generated/packet_decl_payload_field_unknown_size_terminal_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -74,7 +73,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -162,7 +161,7 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
     pub fn specialize(&self) -> FooChild {
         match &self.foo.child {
@@ -170,11 +169,11 @@ impl Foo {
             FooDataChild::None => FooChild::None,
         }
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_a(&self) -> u32 {
-        self.foo.as_ref().a
+        self.foo.a
     }
     pub fn get_payload(&self) -> &[u8] {
         match &self.foo.child {
@@ -191,13 +190,13 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData {
+        let foo = FooData {
             a: self.a,
             child: match self.payload {
                 None => FooDataChild::None,
                 Some(bytes) => FooDataChild::Payload(bytes),
             },
-        });
+        };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_payload_field_unknown_size_terminal_little_endian.rs
+++ b/tests/generated/packet_decl_payload_field_unknown_size_terminal_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -74,7 +73,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -162,7 +161,7 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
     pub fn specialize(&self) -> FooChild {
         match &self.foo.child {
@@ -170,11 +169,11 @@ impl Foo {
             FooDataChild::None => FooChild::None,
         }
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_a(&self) -> u32 {
-        self.foo.as_ref().a
+        self.foo.a
     }
     pub fn get_payload(&self) -> &[u8] {
         match &self.foo.child {
@@ -191,13 +190,13 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData {
+        let foo = FooData {
             a: self.a,
             child: match self.payload {
                 None => FooDataChild::None,
                 Some(bytes) => FooDataChild::Payload(bytes),
             },
-        });
+        };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_reserved_field_big_endian.rs
+++ b/tests/generated/packet_decl_reserved_field_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -51,7 +50,7 @@ pub struct FooData {}
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -114,9 +113,9 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     fn write_to(&self, buffer: &mut BytesMut) {
@@ -128,7 +127,7 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData {});
+        let foo = FooData {};
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_reserved_field_little_endian.rs
+++ b/tests/generated/packet_decl_reserved_field_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -51,7 +50,7 @@ pub struct FooData {}
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -114,9 +113,9 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     fn write_to(&self, buffer: &mut BytesMut) {
@@ -128,7 +127,7 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData {});
+        let foo = FooData {};
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_simple_scalars_big_endian.rs
+++ b/tests/generated/packet_decl_simple_scalars_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -55,7 +54,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -143,19 +142,19 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> u8 {
-        self.foo.as_ref().x
+        self.foo.x
     }
     pub fn get_y(&self) -> u16 {
-        self.foo.as_ref().y
+        self.foo.y
     }
     pub fn get_z(&self) -> u32 {
-        self.foo.as_ref().z
+        self.foo.z
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -166,11 +165,11 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData {
+        let foo = FooData {
             x: self.x,
             y: self.y,
             z: self.z,
-        });
+        };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/packet_decl_simple_scalars_little_endian.rs
+++ b/tests/generated/packet_decl_simple_scalars_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values
@@ -55,7 +54,7 @@ pub struct FooData {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     #[cfg_attr(feature = "serde", serde(flatten))]
-    foo: Arc<FooData>,
+    foo: FooData,
 }
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -143,19 +142,19 @@ impl Foo {
     }
     fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
         let data = FooData::parse_inner(&mut bytes)?;
-        Self::new(Arc::new(data))
+        Self::new(data)
     }
-    fn new(foo: Arc<FooData>) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> u8 {
-        self.foo.as_ref().x
+        self.foo.x
     }
     pub fn get_y(&self) -> u16 {
-        self.foo.as_ref().y
+        self.foo.y
     }
     pub fn get_z(&self) -> u32 {
-        self.foo.as_ref().z
+        self.foo.z
     }
     fn write_to(&self, buffer: &mut BytesMut) {
         self.foo.write_to(buffer)
@@ -166,11 +165,11 @@ impl Foo {
 }
 impl FooBuilder {
     pub fn build(self) -> Foo {
-        let foo = Arc::new(FooData {
+        let foo = FooData {
             x: self.x,
             y: self.y,
             z: self.z,
-        });
+        };
         Foo::new(foo).unwrap()
     }
 }

--- a/tests/generated/preamble.rs
+++ b/tests/generated/preamble.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values

--- a/tests/generated/struct_decl_complex_scalars_big_endian.rs
+++ b/tests/generated/struct_decl_complex_scalars_big_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values

--- a/tests/generated/struct_decl_complex_scalars_little_endian.rs
+++ b/tests/generated/struct_decl_complex_scalars_little_endian.rs
@@ -4,7 +4,6 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use std::sync::Arc;
 use thiserror::Error;
 type Result<T> = std::result::Result<T, Error>;
 /// Private prevents users from creating arbitrary scalar values


### PR DESCRIPTION
The Arc<> is not necessary as the generated code does not share sub-trees
and does not need to be concurrent-friendly.
