### PR TITLE
Generate _ASSERT_VALID under a guard

### DIFF
--- a/scripts/generate_cxx_backend.py
+++ b/scripts/generate_cxx_backend.py
@@ -1542,12 +1542,14 @@ def run(input: argparse.FileType, output: argparse.FileType, namespace: Optional
         {include_header}
         {using_namespace}
 
+        #ifndef _ASSERT_VALID
         #ifdef ASSERT
         #define _ASSERT_VALID ASSERT
         #else
         #include <cassert>
         #define _ASSERT_VALID assert
         #endif  // ASSERT
+        #endif  // !_ASSERT_VALID
 
         {open_namespace}
         """).format(input_name=input.name,


### PR DESCRIPTION
Otherwise generates a compiler error if multiple generated headers
are included in the same source.
