### PR TITLE
Fix double read of invalid enum values

### DIFF
--- a/tests/generated/packet_decl_24bit_enum_array_big_endian.rs
+++ b/tests/generated/packet_decl_24bit_enum_array_big_endian.rs
@@ -125,10 +125,10 @@ impl BarData {
         let x = (0..5)
             .map(|_| {
                 Foo::try_from(bytes.get_mut().get_uint(3) as u32)
-                    .map_err(|_| Error::InvalidEnumValueError {
+                    .map_err(|unknown_val| Error::InvalidEnumValueError {
                         obj: "Bar".to_string(),
                         field: String::new(),
-                        value: 0,
+                        value: unknown_val as u64,
                         type_: "Foo".to_string(),
                     })
             })

--- a/tests/generated/packet_decl_24bit_enum_array_little_endian.rs
+++ b/tests/generated/packet_decl_24bit_enum_array_little_endian.rs
@@ -125,10 +125,10 @@ impl BarData {
         let x = (0..5)
             .map(|_| {
                 Foo::try_from(bytes.get_mut().get_uint_le(3) as u32)
-                    .map_err(|_| Error::InvalidEnumValueError {
+                    .map_err(|unknown_val| Error::InvalidEnumValueError {
                         obj: "Bar".to_string(),
                         field: String::new(),
-                        value: 0,
+                        value: unknown_val as u64,
                         type_: "Foo".to_string(),
                     })
             })

--- a/tests/generated/packet_decl_24bit_enum_big_endian.rs
+++ b/tests/generated/packet_decl_24bit_enum_big_endian.rs
@@ -123,10 +123,10 @@ impl BarData {
             });
         }
         let x = Foo::try_from(bytes.get_mut().get_uint(3) as u32)
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Bar".to_string(),
                 field: "x".to_string(),
-                value: bytes.get_mut().get_uint(3) as u32 as u64,
+                value: unknown_val as u64,
                 type_: "Foo".to_string(),
             })?;
         Ok(Self { x })

--- a/tests/generated/packet_decl_24bit_enum_little_endian.rs
+++ b/tests/generated/packet_decl_24bit_enum_little_endian.rs
@@ -123,10 +123,10 @@ impl BarData {
             });
         }
         let x = Foo::try_from(bytes.get_mut().get_uint_le(3) as u32)
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Bar".to_string(),
                 field: "x".to_string(),
-                value: bytes.get_mut().get_uint_le(3) as u32 as u64,
+                value: unknown_val as u64,
                 type_: "Foo".to_string(),
             })?;
         Ok(Self { x })

--- a/tests/generated/packet_decl_64bit_enum_array_big_endian.rs
+++ b/tests/generated/packet_decl_64bit_enum_array_big_endian.rs
@@ -110,10 +110,10 @@ impl BarData {
         let x = (0..7)
             .map(|_| {
                 Foo::try_from(bytes.get_mut().get_u64())
-                    .map_err(|_| Error::InvalidEnumValueError {
+                    .map_err(|unknown_val| Error::InvalidEnumValueError {
                         obj: "Bar".to_string(),
                         field: String::new(),
-                        value: 0,
+                        value: unknown_val as u64,
                         type_: "Foo".to_string(),
                     })
             })

--- a/tests/generated/packet_decl_64bit_enum_array_little_endian.rs
+++ b/tests/generated/packet_decl_64bit_enum_array_little_endian.rs
@@ -110,10 +110,10 @@ impl BarData {
         let x = (0..7)
             .map(|_| {
                 Foo::try_from(bytes.get_mut().get_u64_le())
-                    .map_err(|_| Error::InvalidEnumValueError {
+                    .map_err(|unknown_val| Error::InvalidEnumValueError {
                         obj: "Bar".to_string(),
                         field: String::new(),
-                        value: 0,
+                        value: unknown_val as u64,
                         type_: "Foo".to_string(),
                     })
             })

--- a/tests/generated/packet_decl_64bit_enum_big_endian.rs
+++ b/tests/generated/packet_decl_64bit_enum_big_endian.rs
@@ -108,10 +108,10 @@ impl BarData {
             });
         }
         let x = Foo::try_from(bytes.get_mut().get_u64())
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Bar".to_string(),
                 field: "x".to_string(),
-                value: bytes.get_mut().get_u64() as u64,
+                value: unknown_val as u64,
                 type_: "Foo".to_string(),
             })?;
         Ok(Self { x })

--- a/tests/generated/packet_decl_64bit_enum_little_endian.rs
+++ b/tests/generated/packet_decl_64bit_enum_little_endian.rs
@@ -108,10 +108,10 @@ impl BarData {
             });
         }
         let x = Foo::try_from(bytes.get_mut().get_u64_le())
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Bar".to_string(),
                 field: "x".to_string(),
-                value: bytes.get_mut().get_u64_le() as u64,
+                value: unknown_val as u64,
                 type_: "Foo".to_string(),
             })?;
         Ok(Self { x })

--- a/tests/generated/packet_decl_8bit_enum_array_big_endian.rs
+++ b/tests/generated/packet_decl_8bit_enum_array_big_endian.rs
@@ -140,10 +140,10 @@ impl BarData {
         let x = (0..3)
             .map(|_| {
                 Foo::try_from(bytes.get_mut().get_u8())
-                    .map_err(|_| Error::InvalidEnumValueError {
+                    .map_err(|unknown_val| Error::InvalidEnumValueError {
                         obj: "Bar".to_string(),
                         field: String::new(),
-                        value: 0,
+                        value: unknown_val as u64,
                         type_: "Foo".to_string(),
                     })
             })

--- a/tests/generated/packet_decl_8bit_enum_array_little_endian.rs
+++ b/tests/generated/packet_decl_8bit_enum_array_little_endian.rs
@@ -140,10 +140,10 @@ impl BarData {
         let x = (0..3)
             .map(|_| {
                 Foo::try_from(bytes.get_mut().get_u8())
-                    .map_err(|_| Error::InvalidEnumValueError {
+                    .map_err(|unknown_val| Error::InvalidEnumValueError {
                         obj: "Bar".to_string(),
                         field: String::new(),
-                        value: 0,
+                        value: unknown_val as u64,
                         type_: "Foo".to_string(),
                     })
             })

--- a/tests/generated/packet_decl_8bit_enum_big_endian.rs
+++ b/tests/generated/packet_decl_8bit_enum_big_endian.rs
@@ -138,10 +138,10 @@ impl BarData {
             });
         }
         let x = Foo::try_from(bytes.get_mut().get_u8())
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Bar".to_string(),
                 field: "x".to_string(),
-                value: bytes.get_mut().get_u8() as u64,
+                value: unknown_val as u64,
                 type_: "Foo".to_string(),
             })?;
         Ok(Self { x })

--- a/tests/generated/packet_decl_8bit_enum_little_endian.rs
+++ b/tests/generated/packet_decl_8bit_enum_little_endian.rs
@@ -138,10 +138,10 @@ impl BarData {
             });
         }
         let x = Foo::try_from(bytes.get_mut().get_u8())
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Bar".to_string(),
                 field: "x".to_string(),
-                value: bytes.get_mut().get_u8() as u64,
+                value: unknown_val as u64,
                 type_: "Foo".to_string(),
             })?;
         Ok(Self { x })

--- a/tests/generated/packet_decl_child_packets_big_endian.rs
+++ b/tests/generated/packet_decl_child_packets_big_endian.rs
@@ -166,10 +166,10 @@ impl FooData {
             });
         }
         let b = Enum16::try_from(bytes.get_mut().get_u16())
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Foo".to_string(),
                 field: "b".to_string(),
-                value: bytes.get_mut().get_u16() as u64,
+                value: unknown_val as u64,
                 type_: "Enum16".to_string(),
             })?;
         if bytes.get().remaining() < 1 {

--- a/tests/generated/packet_decl_child_packets_little_endian.rs
+++ b/tests/generated/packet_decl_child_packets_little_endian.rs
@@ -166,10 +166,10 @@ impl FooData {
             });
         }
         let b = Enum16::try_from(bytes.get_mut().get_u16_le())
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Foo".to_string(),
                 field: "b".to_string(),
-                value: bytes.get_mut().get_u16_le() as u64,
+                value: unknown_val as u64,
                 type_: "Enum16".to_string(),
             })?;
         if bytes.get().remaining() < 1 {

--- a/tests/generated/packet_decl_fixed_enum_field_big_endian.rs
+++ b/tests/generated/packet_decl_fixed_enum_field_big_endian.rs
@@ -143,10 +143,11 @@ impl FooData {
             });
         }
         let chunk = bytes.get_mut().get_u64();
-        if (chunk & 0x7f) as u8 != u8::from(Enum7::A) {
+        let fixed_value = (chunk & 0x7f) as u8;
+        if fixed_value != u8::from(Enum7::A) {
             return Err(Error::InvalidFixedValue {
                 expected: u8::from(Enum7::A) as u64,
-                actual: (chunk & 0x7f) as u8 as u64,
+                actual: fixed_value as u64,
             });
         }
         let b = ((chunk >> 7) & 0x1ff_ffff_ffff_ffff_u64);

--- a/tests/generated/packet_decl_fixed_enum_field_little_endian.rs
+++ b/tests/generated/packet_decl_fixed_enum_field_little_endian.rs
@@ -143,10 +143,11 @@ impl FooData {
             });
         }
         let chunk = bytes.get_mut().get_u64_le();
-        if (chunk & 0x7f) as u8 != u8::from(Enum7::A) {
+        let fixed_value = (chunk & 0x7f) as u8;
+        if fixed_value != u8::from(Enum7::A) {
             return Err(Error::InvalidFixedValue {
                 expected: u8::from(Enum7::A) as u64,
-                actual: (chunk & 0x7f) as u8 as u64,
+                actual: fixed_value as u64,
             });
         }
         let b = ((chunk >> 7) & 0x1ff_ffff_ffff_ffff_u64);

--- a/tests/generated/packet_decl_fixed_scalar_field_big_endian.rs
+++ b/tests/generated/packet_decl_fixed_scalar_field_big_endian.rs
@@ -77,10 +77,11 @@ impl FooData {
             });
         }
         let chunk = bytes.get_mut().get_u64();
+        let fixed_value = (chunk & 0x7f) as u8;
         if (chunk & 0x7f) as u8 != 7 {
             return Err(Error::InvalidFixedValue {
                 expected: 7,
-                actual: (chunk & 0x7f) as u8 as u64,
+                actual: fixed_value as u64,
             });
         }
         let b = ((chunk >> 7) & 0x1ff_ffff_ffff_ffff_u64);

--- a/tests/generated/packet_decl_fixed_scalar_field_little_endian.rs
+++ b/tests/generated/packet_decl_fixed_scalar_field_little_endian.rs
@@ -77,10 +77,11 @@ impl FooData {
             });
         }
         let chunk = bytes.get_mut().get_u64_le();
+        let fixed_value = (chunk & 0x7f) as u8;
         if (chunk & 0x7f) as u8 != 7 {
             return Err(Error::InvalidFixedValue {
                 expected: 7,
-                actual: (chunk & 0x7f) as u8 as u64,
+                actual: fixed_value as u64,
             });
         }
         let b = ((chunk >> 7) & 0x1ff_ffff_ffff_ffff_u64);

--- a/tests/generated/packet_decl_grand_children_big_endian.rs
+++ b/tests/generated/packet_decl_grand_children_big_endian.rs
@@ -157,10 +157,10 @@ impl ParentData {
             });
         }
         let foo = Enum16::try_from(bytes.get_mut().get_u16())
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Parent".to_string(),
                 field: "foo".to_string(),
-                value: bytes.get_mut().get_u16() as u64,
+                value: unknown_val as u64,
                 type_: "Enum16".to_string(),
             })?;
         if bytes.get().remaining() < 2 {
@@ -171,10 +171,10 @@ impl ParentData {
             });
         }
         let bar = Enum16::try_from(bytes.get_mut().get_u16())
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Parent".to_string(),
                 field: "bar".to_string(),
-                value: bytes.get_mut().get_u16() as u64,
+                value: unknown_val as u64,
                 type_: "Enum16".to_string(),
             })?;
         if bytes.get().remaining() < 2 {
@@ -185,10 +185,10 @@ impl ParentData {
             });
         }
         let baz = Enum16::try_from(bytes.get_mut().get_u16())
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Parent".to_string(),
                 field: "baz".to_string(),
-                value: bytes.get_mut().get_u16() as u64,
+                value: unknown_val as u64,
                 type_: "Enum16".to_string(),
             })?;
         if bytes.get().remaining() < 1 {
@@ -389,10 +389,10 @@ impl ChildData {
             });
         }
         let quux = Enum16::try_from(bytes.get_mut().get_u16())
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Child".to_string(),
                 field: "quux".to_string(),
-                value: bytes.get_mut().get_u16() as u64,
+                value: unknown_val as u64,
                 type_: "Enum16".to_string(),
             })?;
         let payload = bytes.get();

--- a/tests/generated/packet_decl_grand_children_little_endian.rs
+++ b/tests/generated/packet_decl_grand_children_little_endian.rs
@@ -157,10 +157,10 @@ impl ParentData {
             });
         }
         let foo = Enum16::try_from(bytes.get_mut().get_u16_le())
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Parent".to_string(),
                 field: "foo".to_string(),
-                value: bytes.get_mut().get_u16_le() as u64,
+                value: unknown_val as u64,
                 type_: "Enum16".to_string(),
             })?;
         if bytes.get().remaining() < 2 {
@@ -171,10 +171,10 @@ impl ParentData {
             });
         }
         let bar = Enum16::try_from(bytes.get_mut().get_u16_le())
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Parent".to_string(),
                 field: "bar".to_string(),
-                value: bytes.get_mut().get_u16_le() as u64,
+                value: unknown_val as u64,
                 type_: "Enum16".to_string(),
             })?;
         if bytes.get().remaining() < 2 {
@@ -185,10 +185,10 @@ impl ParentData {
             });
         }
         let baz = Enum16::try_from(bytes.get_mut().get_u16_le())
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Parent".to_string(),
                 field: "baz".to_string(),
-                value: bytes.get_mut().get_u16_le() as u64,
+                value: unknown_val as u64,
                 type_: "Enum16".to_string(),
             })?;
         if bytes.get().remaining() < 1 {
@@ -389,10 +389,10 @@ impl ChildData {
             });
         }
         let quux = Enum16::try_from(bytes.get_mut().get_u16_le())
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Child".to_string(),
                 field: "quux".to_string(),
-                value: bytes.get_mut().get_u16_le() as u64,
+                value: unknown_val as u64,
                 type_: "Enum16".to_string(),
             })?;
         let payload = bytes.get();

--- a/tests/generated/packet_decl_mixed_scalars_enums_big_endian.rs
+++ b/tests/generated/packet_decl_mixed_scalars_enums_big_endian.rs
@@ -206,18 +206,18 @@ impl FooData {
         }
         let chunk = bytes.get_mut().get_uint(3) as u32;
         let x = Enum7::try_from((chunk & 0x7f) as u8)
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Foo".to_string(),
                 field: "x".to_string(),
-                value: (chunk & 0x7f) as u8 as u64,
+                value: unknown_val as u64,
                 type_: "Enum7".to_string(),
             })?;
         let y = ((chunk >> 7) & 0x1f) as u8;
         let z = Enum9::try_from(((chunk >> 12) & 0x1ff) as u16)
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Foo".to_string(),
                 field: "z".to_string(),
-                value: ((chunk >> 12) & 0x1ff) as u16 as u64,
+                value: unknown_val as u64,
                 type_: "Enum9".to_string(),
             })?;
         let w = ((chunk >> 21) & 0x7) as u8;

--- a/tests/generated/packet_decl_mixed_scalars_enums_little_endian.rs
+++ b/tests/generated/packet_decl_mixed_scalars_enums_little_endian.rs
@@ -206,18 +206,18 @@ impl FooData {
         }
         let chunk = bytes.get_mut().get_uint_le(3) as u32;
         let x = Enum7::try_from((chunk & 0x7f) as u8)
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Foo".to_string(),
                 field: "x".to_string(),
-                value: (chunk & 0x7f) as u8 as u64,
+                value: unknown_val as u64,
                 type_: "Enum7".to_string(),
             })?;
         let y = ((chunk >> 7) & 0x1f) as u8;
         let z = Enum9::try_from(((chunk >> 12) & 0x1ff) as u16)
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Foo".to_string(),
                 field: "z".to_string(),
-                value: ((chunk >> 12) & 0x1ff) as u16 as u64,
+                value: unknown_val as u64,
                 type_: "Enum9".to_string(),
             })?;
         let w = ((chunk >> 21) & 0x7) as u8;

--- a/tests/generated/packet_decl_parent_with_alias_child_big_endian.rs
+++ b/tests/generated/packet_decl_parent_with_alias_child_big_endian.rs
@@ -169,10 +169,10 @@ impl ParentData {
             });
         }
         let v = Enum8::try_from(bytes.get_mut().get_u8())
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Parent".to_string(),
                 field: "v".to_string(),
-                value: bytes.get_mut().get_u8() as u64,
+                value: unknown_val as u64,
                 type_: "Enum8".to_string(),
             })?;
         let payload = bytes.get();

--- a/tests/generated/packet_decl_parent_with_alias_child_little_endian.rs
+++ b/tests/generated/packet_decl_parent_with_alias_child_little_endian.rs
@@ -169,10 +169,10 @@ impl ParentData {
             });
         }
         let v = Enum8::try_from(bytes.get_mut().get_u8())
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Parent".to_string(),
                 field: "v".to_string(),
-                value: bytes.get_mut().get_u8() as u64,
+                value: unknown_val as u64,
                 type_: "Enum8".to_string(),
             })?;
         let payload = bytes.get();

--- a/tests/generated/packet_decl_parent_with_no_payload_big_endian.rs
+++ b/tests/generated/packet_decl_parent_with_no_payload_big_endian.rs
@@ -160,10 +160,10 @@ impl ParentData {
             });
         }
         let v = Enum8::try_from(bytes.get_mut().get_u8())
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Parent".to_string(),
                 field: "v".to_string(),
-                value: bytes.get_mut().get_u8() as u64,
+                value: unknown_val as u64,
                 type_: "Enum8".to_string(),
             })?;
         let payload: &[u8] = &[];

--- a/tests/generated/packet_decl_parent_with_no_payload_little_endian.rs
+++ b/tests/generated/packet_decl_parent_with_no_payload_little_endian.rs
@@ -160,10 +160,10 @@ impl ParentData {
             });
         }
         let v = Enum8::try_from(bytes.get_mut().get_u8())
-            .map_err(|_| Error::InvalidEnumValueError {
+            .map_err(|unknown_val| Error::InvalidEnumValueError {
                 obj: "Parent".to_string(),
                 field: "v".to_string(),
-                value: bytes.get_mut().get_u8() as u64,
+                value: unknown_val as u64,
                 type_: "Enum8".to_string(),
             })?;
         let payload: &[u8] = &[];


### PR DESCRIPTION
The invalid enum value is read a second time to generate the
error message when read as a bitfield. This is invalid
as reading potentially consumes the input bytes.
