### PR TITLE
double read

### DIFF
--- a/scripts/generate_cxx_backend.py
+++ b/scripts/generate_cxx_backend.py
@@ -1558,6 +1558,12 @@ def run(input: argparse.FileType, output: argparse.FileType, namespace: Optional
                     using_namespace=using_namespace,
                     open_namespace=open_namespace))
 
+    # Forward declarations for packet classes.
+    # Required for the friend class specifiers.
+    for d in file.declarations:
+        if isinstance(d, ast.PacketDeclaration):
+            output.write(f"class {d.id}View;\n")
+
     for d in file.declarations:
         if d.id in skipped_decls:
             continue

--- a/src/backends/rust/parser.rs
+++ b/src/backends/rust/parser.rs
@@ -164,7 +164,7 @@ impl<'a> FieldParser<'a> {
                     let value = proc_macro2::Literal::usize_unsuffixed(*value);
                     quote! {
                         let fixed_value = #v;
-                        if #v != #value {
+                        if fixed_value != #value {
                             return Err(Error::InvalidFixedValue {
                                 expected: #value,
                                 actual: fixed_value as u64,

--- a/tests/generated/packet_decl_fixed_scalar_field_big_endian.rs
+++ b/tests/generated/packet_decl_fixed_scalar_field_big_endian.rs
@@ -78,7 +78,7 @@ impl FooData {
         }
         let chunk = bytes.get_mut().get_u64();
         let fixed_value = (chunk & 0x7f) as u8;
-        if (chunk & 0x7f) as u8 != 7 {
+        if fixed_value != 7 {
             return Err(Error::InvalidFixedValue {
                 expected: 7,
                 actual: fixed_value as u64,

--- a/tests/generated/packet_decl_fixed_scalar_field_little_endian.rs
+++ b/tests/generated/packet_decl_fixed_scalar_field_little_endian.rs
@@ -78,7 +78,7 @@ impl FooData {
         }
         let chunk = bytes.get_mut().get_u64_le();
         let fixed_value = (chunk & 0x7f) as u8;
-        if (chunk & 0x7f) as u8 != 7 {
+        if fixed_value != 7 {
             return Err(Error::InvalidFixedValue {
                 expected: 7,
                 actual: fixed_value as u64,


### PR DESCRIPTION
- Generate forward declarations for packet view classes
- Value of fixed value field may be read twice from the input buffer
