### PR TITLE
Move all preamble definitions to a new pdl-runtime crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 members = [
     "pdl-compiler",
     "pdl-derive",
+    "pdl-runtime",
 ]

--- a/doc/rust-generated-code-guide.rst
+++ b/doc/rust-generated-code-guide.rst
@@ -9,7 +9,8 @@ using the `pdl` proc_macro attribute. Example usage:
 
 .. sourcecode:: rust
 
-        use pdl_derive::pdl
+        use pdl_derive::pdl;
+        use pdl_runtime::*;
 
         #[pdl("my-protocol.pdl")]
         mod my_protocol {
@@ -32,8 +33,8 @@ Language bindings
 This section contains the generated rust bindings for language constructs that
 are stabilized.
 
-Preamble
-^^^^^^^^
+Runtime
+^^^^^^^
 
 Private prevents users from creating arbitrary scalar values in situations where
 the value needs to be validated. Users can freely deref the value, but only the

--- a/pdl-compiler/src/backends/rust/preamble.rs
+++ b/pdl-compiler/src/backends/rust/preamble.rs
@@ -55,48 +55,9 @@ pub fn generate(path: &Path) -> proc_macro2::TokenStream {
         use std::convert::{TryFrom, TryInto};
         use std::cell::Cell;
         use std::fmt;
-        use thiserror::Error;
+        use pdl_runtime::{Error, Packet, Private};
 
         type Result<T> = std::result::Result<T, Error>;
-
-        /// Private prevents users from creating arbitrary scalar values
-        /// in situations where the value needs to be validated.
-        /// Users can freely deref the value, but only the backend
-        /// may create it.
-        #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-        pub struct Private<T>(T);
-
-        impl<T> std::ops::Deref for Private<T> {
-            type Target = T;
-            fn deref(&self) -> &Self::Target {
-                &self.0
-            }
-        }
-
-        #[derive(Debug, Error)]
-        pub enum Error {
-            #[error("Packet parsing failed")]
-            InvalidPacketError,
-            #[error("{field} was {value:x}, which is not known")]
-            ConstraintOutOfBounds { field: String, value: u64 },
-            #[error("Got {actual:x}, expected {expected:x}")]
-            InvalidFixedValue { expected: u64, actual: u64 },
-            #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-            InvalidLengthError { obj: String, wanted: usize, got: usize },
-            #[error("array size ({array} bytes) is not a multiple of the element size ({element} bytes)")]
-            InvalidArraySize { array: usize, element: usize },
-            #[error("Due to size restrictions a struct could not be parsed.")]
-            ImpossibleStructError,
-            #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-            InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-            #[error("expected child {expected}, got {actual}")]
-            InvalidChildError { expected: &'static str, actual: String },
-        }
-
-        pub trait Packet {
-            fn to_bytes(self) -> Bytes;
-            fn to_vec(self) -> Vec<u8>;
-        }
     }
 }
 

--- a/pdl-compiler/tests/generated/custom_field_declaration_big_endian.rs
+++ b/pdl-compiler/tests/generated/custom_field_declaration_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(from = "u32", into = "u32"))]

--- a/pdl-compiler/tests/generated/custom_field_declaration_little_endian.rs
+++ b/pdl-compiler/tests/generated/custom_field_declaration_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(from = "u32", into = "u32"))]

--- a/pdl-compiler/tests/generated/enum_declaration_big_endian.rs
+++ b/pdl-compiler/tests/generated/enum_declaration_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/enum_declaration_little_endian.rs
+++ b/pdl-compiler/tests/generated/enum_declaration_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_24bit_enum_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_24bit_enum_array_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_24bit_enum_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_24bit_enum_array_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_24bit_enum_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_24bit_enum_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_24bit_enum_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_24bit_enum_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_24bit_scalar_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_24bit_scalar_array_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_24bit_scalar_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_24bit_scalar_array_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_24bit_scalar_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_24bit_scalar_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_24bit_scalar_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_24bit_scalar_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_64bit_enum_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_enum_array_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_64bit_enum_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_enum_array_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_64bit_enum_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_enum_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_64bit_enum_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_enum_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_64bit_scalar_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_scalar_array_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_64bit_scalar_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_scalar_array_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_64bit_scalar_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_scalar_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_64bit_scalar_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_scalar_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_8bit_enum_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_enum_array_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_8bit_enum_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_enum_array_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_8bit_enum_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_enum_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_8bit_enum_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_enum_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_8bit_scalar_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_scalar_array_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_8bit_scalar_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_scalar_array_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_8bit_scalar_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_scalar_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_8bit_scalar_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_scalar_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_array_dynamic_count_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_dynamic_count_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_array_dynamic_count_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_dynamic_count_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_array_dynamic_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_dynamic_size_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_array_dynamic_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_dynamic_size_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_count_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_count_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {

--- a/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_count_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_count_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {

--- a/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_size_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {

--- a/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_size_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {

--- a/pdl-compiler/tests/generated/packet_decl_array_with_padding_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_with_padding_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {

--- a/pdl-compiler/tests/generated/packet_decl_array_with_padding_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_with_padding_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {

--- a/pdl-compiler/tests/generated/packet_decl_child_packets_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_child_packets_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_child_packets_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_child_packets_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_complex_scalars_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_complex_scalars_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_complex_scalars_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_complex_scalars_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_custom_field_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_custom_field_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u32", into = "u32"))]

--- a/pdl-compiler/tests/generated/packet_decl_custom_field_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_custom_field_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u32", into = "u32"))]

--- a/pdl-compiler/tests/generated/packet_decl_empty_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_empty_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {}

--- a/pdl-compiler/tests/generated/packet_decl_empty_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_empty_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {}

--- a/pdl-compiler/tests/generated/packet_decl_fixed_enum_field_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_fixed_enum_field_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_fixed_enum_field_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_fixed_enum_field_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_fixed_scalar_field_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_fixed_scalar_field_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_fixed_scalar_field_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_fixed_scalar_field_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_grand_children_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_grand_children_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_grand_children_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_grand_children_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_mask_scalar_value_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_mask_scalar_value_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_mask_scalar_value_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_mask_scalar_value_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_mixed_scalars_enums_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_mixed_scalars_enums_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_mixed_scalars_enums_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_mixed_scalars_enums_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_parent_with_alias_child_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_parent_with_alias_child_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_parent_with_alias_child_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_parent_with_alias_child_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_parent_with_no_payload_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_parent_with_no_payload_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_parent_with_no_payload_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_parent_with_no_payload_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[repr(u64)]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/pdl-compiler/tests/generated/packet_decl_payload_field_unknown_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_payload_field_unknown_size_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FooDataChild {

--- a/pdl-compiler/tests/generated/packet_decl_payload_field_unknown_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_payload_field_unknown_size_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FooDataChild {

--- a/pdl-compiler/tests/generated/packet_decl_payload_field_unknown_size_terminal_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_payload_field_unknown_size_terminal_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FooDataChild {

--- a/pdl-compiler/tests/generated/packet_decl_payload_field_unknown_size_terminal_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_payload_field_unknown_size_terminal_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FooDataChild {

--- a/pdl-compiler/tests/generated/packet_decl_payload_field_variable_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_payload_field_variable_size_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FooDataChild {

--- a/pdl-compiler/tests/generated/packet_decl_payload_field_variable_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_payload_field_variable_size_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FooDataChild {

--- a/pdl-compiler/tests/generated/packet_decl_reserved_field_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_reserved_field_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {}

--- a/pdl-compiler/tests/generated/packet_decl_reserved_field_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_reserved_field_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {}

--- a/pdl-compiler/tests/generated/packet_decl_simple_scalars_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_simple_scalars_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/packet_decl_simple_scalars_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_simple_scalars_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FooData {

--- a/pdl-compiler/tests/generated/preamble.rs
+++ b/pdl-compiler/tests/generated/preamble.rs
@@ -4,42 +4,5 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}

--- a/pdl-compiler/tests/generated/reserved_identifier_big_endian.rs
+++ b/pdl-compiler/tests/generated/reserved_identifier_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TestData {

--- a/pdl-compiler/tests/generated/reserved_identifier_little_endian.rs
+++ b/pdl-compiler/tests/generated/reserved_identifier_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TestData {

--- a/pdl-compiler/tests/generated/struct_decl_complex_scalars_big_endian.rs
+++ b/pdl-compiler/tests/generated/struct_decl_complex_scalars_big_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {

--- a/pdl-compiler/tests/generated/struct_decl_complex_scalars_little_endian.rs
+++ b/pdl-compiler/tests/generated/struct_decl_complex_scalars_little_endian.rs
@@ -4,45 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use thiserror::Error;
+use pdl_runtime::{Error, Packet, Private};
 type Result<T> = std::result::Result<T, Error>;
-/// Private prevents users from creating arbitrary scalar values
-/// in situations where the value needs to be validated.
-/// Users can freely deref the value, but only the backend
-/// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Private<T>(T);
-impl<T> std::ops::Deref for Private<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("Packet parsing failed")]
-    InvalidPacketError,
-    #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
-    #[error("Got {actual:x}, expected {expected:x}")]
-    InvalidFixedValue { expected: u64, actual: u64 },
-    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
-    #[error(
-        "array size ({array} bytes) is not a multiple of the element size ({element} bytes)"
-    )]
-    InvalidArraySize { array: usize, element: usize },
-    #[error("Due to size restrictions a struct could not be parsed.")]
-    ImpossibleStructError,
-    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
-    #[error("expected child {expected}, got {actual}")]
-    InvalidChildError { expected: &'static str, actual: String },
-}
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {

--- a/pdl-derive/tests/examples.rs
+++ b/pdl-derive/tests/examples.rs
@@ -22,6 +22,8 @@ fn test_pcap() {
     mod pcap {}
 
     use pcap::*;
+    use pdl_runtime::Packet;
+
     let pcap_file = PcapFileBuilder {
         header: PcapHeader {
             version_major: 1,

--- a/pdl-runtime/Cargo.toml
+++ b/pdl-runtime/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "pdl-derive"
+name = "pdl-runtime"
 version = "0.1.7"
 edition = "2021"
-description = "PDL's derive macro"
+description = "PDL's runtime library"
 repository = "https://github.com/google/pdl/"
 license = "Apache-2.0"
 readme = "../README.md"
@@ -12,21 +12,8 @@ authors = [
     "David de Jesus Duarte <licorne@google.com>",
     "Martin Geisler <mgeisler@google.com>"
 ]
-exclude = ["editors/*"]
 categories = ["parsing"]
 
-[lib]
-name = "pdl_derive"
-proc-macro = true
-
 [dependencies]
-codespan-reporting = "0.11.1"
-pdl-compiler = {path = "../pdl-compiler", version = "0.1.7"}
-proc-macro2 = "1.0.66"
-quote = "1.0.33"
-syn = {version = "2.0.29", features = ["full"]}
-termcolor = "1.2.0"
-
-[dev-dependencies]
-pdl-runtime = {path = "../pdl-runtime", version = "0.1.7"}
 bytes = "1.4.0"
+thiserror = "1.0.47"

--- a/pdl-runtime/src/lib.rs
+++ b/pdl-runtime/src/lib.rs
@@ -1,0 +1,59 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Helper definitions used used by the generated Rust backend.
+
+use bytes::Bytes;
+use thiserror::Error;
+
+/// Type of parsing errors.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Packet parsing failed")]
+    InvalidPacketError,
+    #[error("{field} was {value:x}, which is not known")]
+    ConstraintOutOfBounds { field: String, value: u64 },
+    #[error("Got {actual:x}, expected {expected:x}")]
+    InvalidFixedValue { expected: u64, actual: u64 },
+    #[error("when parsing {obj} needed length of {wanted} but got {got}")]
+    InvalidLengthError { obj: String, wanted: usize, got: usize },
+    #[error("array size ({array} bytes) is not a multiple of the element size ({element} bytes)")]
+    InvalidArraySize { array: usize, element: usize },
+    #[error("Due to size restrictions a struct could not be parsed.")]
+    ImpossibleStructError,
+    #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
+    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
+    #[error("expected child {expected}, got {actual}")]
+    InvalidChildError { expected: &'static str, actual: String },
+}
+
+/// Trait implemented for all toplevel packet declarations.
+pub trait Packet {
+    fn to_bytes(self) -> Bytes;
+    fn to_vec(self) -> Vec<u8>;
+}
+
+/// Private prevents users from creating arbitrary scalar values
+/// in situations where the value needs to be validated.
+/// Users can freely deref the value, but only the backend
+/// may create it.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Private<T>(T);
+
+impl<T> std::ops::Deref for Private<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}


### PR DESCRIPTION
The pdl-runtime crate will hold all common definitions for the
generated modules. Currently it defines
  - Error: type of parsing errors
  - Packet: trait for top-level packets
  - Private: wrapper for opaque scalar fields
