### PR TITLE
Make the rust_no_allocation backend deterministic

### DIFF
--- a/pdl-compiler/src/backends/rust_no_allocation/mod.rs
+++ b/pdl-compiler/src/backends/rust_no_allocation/mod.rs
@@ -73,12 +73,8 @@ pub fn generate(file: &parser::ast::File, schema: &Schema) -> Result<String, Str
         .map(|decl| generate_decl(decl, schema, &children))
         .collect::<Result<TokenStream, _>>()?;
 
-    out.push_str(
-        &quote! {
-            #declarations
-        }
-        .to_string(),
-    );
+    let syntax_tree = syn::parse2(declarations).expect("Could not parse code");
+    out.push_str(&prettyplease::unparse(&syntax_tree));
 
     Ok(out)
 }

--- a/pdl-compiler/src/lib.rs
+++ b/pdl-compiler/src/lib.rs
@@ -20,3 +20,65 @@ pub mod backends;
 pub mod parser;
 #[cfg(test)]
 pub mod test_utils;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn rust_no_allocation_output_is_deterministic() {
+        // The generated code should be deterministic, to avoid unnecessary rebuilds during
+        // incremental builds.
+        let src = r#"
+little_endian_packets
+
+enum Enum1 : 8 {
+  ENUM_VARIANT_ONE = 0x01,
+  ENUM_VARIANT_TWO = 0x02,
+}
+
+packet Packet1 {
+  opcode : Enum1,
+  _payload_,
+}
+
+struct Struct1 {
+  handle : 16,
+}
+
+struct Struct2 {
+  _payload_
+}
+
+struct Struct3 {
+  handle : Struct1,
+  value : Struct2,
+}
+
+packet Packet2 : Packet1(opcode = ENUM_VARIANT_ONE) {
+  handle : Struct1,
+  value : Struct2,
+}
+"#
+        .to_owned();
+
+        let mut sources1 = ast::SourceDatabase::new();
+        let mut sources2 = ast::SourceDatabase::new();
+        let mut sources3 = ast::SourceDatabase::new();
+
+        let file1 = parser::parse_inline(&mut sources1, "foo", src.clone()).unwrap();
+        let file2 = parser::parse_inline(&mut sources2, "foo", src.clone()).unwrap();
+        let file3 = parser::parse_inline(&mut sources3, "foo", src).unwrap();
+
+        let schema1 = backends::intermediate::generate(&file1).unwrap();
+        let schema2 = backends::intermediate::generate(&file2).unwrap();
+        let schema3 = backends::intermediate::generate(&file3).unwrap();
+
+        let result1 = backends::rust_no_allocation::generate(&file1, &schema1).unwrap();
+        let result2 = backends::rust_no_allocation::generate(&file2, &schema2).unwrap();
+        let result3 = backends::rust_no_allocation::generate(&file3, &schema3).unwrap();
+
+        assert_eq!(result1, result2);
+        assert_eq!(result2, result3);
+    }
+}


### PR DESCRIPTION
Having non-deterministic generated sources means that incremental builds would have extra recompilations.

Also pretty-print the generated code.

The non-determinism was discovered in some android modules like [bluetooth_core_rust_packets](https://cs.android.com/android/platform/superproject/main/+/main:packages/modules/Bluetooth/system/rust/Android.bp;l=195;drc=d9229010d8557c06c0a09d44f8fb201fef715cc7)
