### PR TITLE
Refactor encoding methods of the Packet trait

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,3 +96,6 @@ jobs:
 
       - name: Run Python generator tests
         run: pdl-compiler/tests/run_python_generator_tests.sh
+
+      - name: Compile Rust generated files
+        run: pdl-compiler/tests/compile_rust_generated_files.sh

--- a/pdl-compiler/src/backends/rust/preamble.rs
+++ b/pdl-compiler/src/backends/rust/preamble.rs
@@ -55,9 +55,8 @@ pub fn generate(path: &Path) -> proc_macro2::TokenStream {
         use std::convert::{TryFrom, TryInto};
         use std::cell::Cell;
         use std::fmt;
-        use pdl_runtime::{Error, Packet};
-
-        type Result<T> = std::result::Result<T, Error>;
+        use std::result::Result;
+        use pdl_runtime::{DecodeError, EncodeError, Packet};
 
         /// Private prevents users from creating arbitrary scalar values
         /// in situations where the value needs to be validated.

--- a/pdl-compiler/src/bin/generate-canonical-tests.rs
+++ b/pdl-compiler/src/bin/generate-canonical-tests.rs
@@ -121,7 +121,7 @@ fn generate_unit_tests(input: &str, packet_names: &[&str], module_name: &str) {
                         .expect("Could not create builder from canonical JSON data");
                     let packet = builder.build();
                     let packed: Vec<u8> = #packed;
-                    assert_eq!(packet.to_vec(), packed);
+                    assert_eq!(packet.encode_to_vec(), Ok(packed));
                 }
             });
         }

--- a/pdl-compiler/tests/compile_rust_generated_files.sh
+++ b/pdl-compiler/tests/compile_rust_generated_files.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+mkdir -p out/
+OUT_DIR="$(pwd)/out"
+
+# move to `pdl-compiler` directory
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." &> /dev/null
+
+mkdir -p "$OUT_DIR/generated_test/src"
+./tests/generated_files_compile.sh tests/generated/*.rs > "$OUT_DIR/generated_test/src/lib.rs"
+
+cat <<EOT > "$OUT_DIR/generated_test/Cargo.toml"
+[package]
+name = "generated_test"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[features]
+default = ["serde"]
+
+[dependencies]
+bytes = {version = "1.4.0", features = ["serde"]}
+thiserror = "1.0.47"
+serde_json = "1.0.86"
+
+[dependencies.serde]
+version = "1.0.145"
+features = ["default", "derive", "serde_derive", "std", "rc"]
+optional = true
+
+[dependencies.pdl-runtime]
+path = "../../pdl-runtime"
+
+[workspace]
+EOT
+
+cd "$OUT_DIR/generated_test"
+RUSTFLAGS=-Awarnings cargo build

--- a/pdl-compiler/tests/generated/custom_field_declaration_big_endian.rs
+++ b/pdl-compiler/tests/generated/custom_field_declaration_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -53,7 +53,7 @@ impl From<TruncatedSize> for u32 {
 }
 impl TryFrom<u32> for TruncatedSize {
     type Error = u32;
-    fn try_from(value: u32) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
         if value > 0xff_ffff { Err(value) } else { Ok(TruncatedSize(value)) }
     }
 }

--- a/pdl-compiler/tests/generated/custom_field_declaration_little_endian.rs
+++ b/pdl-compiler/tests/generated/custom_field_declaration_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -53,7 +53,7 @@ impl From<TruncatedSize> for u32 {
 }
 impl TryFrom<u32> for TruncatedSize {
     type Error = u32;
-    fn try_from(value: u32) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
         if value > 0xff_ffff { Err(value) } else { Ok(TruncatedSize(value)) }
     }
 }

--- a/pdl-compiler/tests/generated/enum_declaration_big_endian.rs
+++ b/pdl-compiler/tests/generated/enum_declaration_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -28,7 +28,7 @@ pub enum IncompleteTruncatedClosed {
 }
 impl TryFrom<u8> for IncompleteTruncatedClosed {
     type Error = u8;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x0 => Ok(IncompleteTruncatedClosed::A),
             0x1 => Ok(IncompleteTruncatedClosed::B),
@@ -94,7 +94,7 @@ pub enum IncompleteTruncatedOpen {
 }
 impl TryFrom<u8> for IncompleteTruncatedOpen {
     type Error = u8;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x0 => Ok(IncompleteTruncatedOpen::A),
             0x1 => Ok(IncompleteTruncatedOpen::B),
@@ -163,7 +163,7 @@ pub enum IncompleteTruncatedClosedWithRange {
 }
 impl TryFrom<u8> for IncompleteTruncatedClosedWithRange {
     type Error = u8;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x0 => Ok(IncompleteTruncatedClosedWithRange::A),
             0x1 => Ok(IncompleteTruncatedClosedWithRange::X),
@@ -235,7 +235,7 @@ pub enum IncompleteTruncatedOpenWithRange {
 }
 impl TryFrom<u8> for IncompleteTruncatedOpenWithRange {
     type Error = u8;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x0 => Ok(IncompleteTruncatedOpenWithRange::A),
             0x1 => Ok(IncompleteTruncatedOpenWithRange::X),
@@ -313,7 +313,7 @@ pub enum CompleteTruncated {
 }
 impl TryFrom<u8> for CompleteTruncated {
     type Error = u8;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x0 => Ok(CompleteTruncated::A),
             0x1 => Ok(CompleteTruncated::B),
@@ -392,7 +392,7 @@ pub enum CompleteTruncatedWithRange {
 }
 impl TryFrom<u8> for CompleteTruncatedWithRange {
     type Error = u8;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x0 => Ok(CompleteTruncatedWithRange::A),
             0x1 => Ok(CompleteTruncatedWithRange::X),
@@ -462,7 +462,7 @@ pub enum CompleteWithRange {
 }
 impl TryFrom<u8> for CompleteWithRange {
     type Error = u8;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x0 => Ok(CompleteWithRange::A),
             0x1 => Ok(CompleteWithRange::B),

--- a/pdl-compiler/tests/generated/enum_declaration_little_endian.rs
+++ b/pdl-compiler/tests/generated/enum_declaration_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -28,7 +28,7 @@ pub enum IncompleteTruncatedClosed {
 }
 impl TryFrom<u8> for IncompleteTruncatedClosed {
     type Error = u8;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x0 => Ok(IncompleteTruncatedClosed::A),
             0x1 => Ok(IncompleteTruncatedClosed::B),
@@ -94,7 +94,7 @@ pub enum IncompleteTruncatedOpen {
 }
 impl TryFrom<u8> for IncompleteTruncatedOpen {
     type Error = u8;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x0 => Ok(IncompleteTruncatedOpen::A),
             0x1 => Ok(IncompleteTruncatedOpen::B),
@@ -163,7 +163,7 @@ pub enum IncompleteTruncatedClosedWithRange {
 }
 impl TryFrom<u8> for IncompleteTruncatedClosedWithRange {
     type Error = u8;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x0 => Ok(IncompleteTruncatedClosedWithRange::A),
             0x1 => Ok(IncompleteTruncatedClosedWithRange::X),
@@ -235,7 +235,7 @@ pub enum IncompleteTruncatedOpenWithRange {
 }
 impl TryFrom<u8> for IncompleteTruncatedOpenWithRange {
     type Error = u8;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x0 => Ok(IncompleteTruncatedOpenWithRange::A),
             0x1 => Ok(IncompleteTruncatedOpenWithRange::X),
@@ -313,7 +313,7 @@ pub enum CompleteTruncated {
 }
 impl TryFrom<u8> for CompleteTruncated {
     type Error = u8;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x0 => Ok(CompleteTruncated::A),
             0x1 => Ok(CompleteTruncated::B),
@@ -392,7 +392,7 @@ pub enum CompleteTruncatedWithRange {
 }
 impl TryFrom<u8> for CompleteTruncatedWithRange {
     type Error = u8;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x0 => Ok(CompleteTruncatedWithRange::A),
             0x1 => Ok(CompleteTruncatedWithRange::X),
@@ -462,7 +462,7 @@ pub enum CompleteWithRange {
 }
 impl TryFrom<u8> for CompleteWithRange {
     type Error = u8;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x0 => Ok(CompleteWithRange::A),
             0x1 => Ok(CompleteWithRange::B),

--- a/pdl-compiler/tests/generated/packet_decl_24bit_enum_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_24bit_enum_array_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -28,7 +28,7 @@ pub enum Foo {
 }
 impl TryFrom<u32> for Foo {
     type Error = u32;
-    fn try_from(value: u32) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
         match value {
             0x1 => Ok(Foo::FooBar),
             0x2 => Ok(Foo::Baz),
@@ -84,15 +84,15 @@ impl BarData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 15
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 5 * 3 {
-            return Err(Error::InvalidLengthError {
-                obj: "Bar".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Bar",
                 wanted: 5 * 3,
                 got: bytes.get().remaining(),
             });
@@ -100,22 +100,23 @@ impl BarData {
         let x = (0..5)
             .map(|_| {
                 Foo::try_from(bytes.get_mut().get_uint(3) as u32)
-                    .map_err(|unknown_val| Error::InvalidEnumValueError {
-                        obj: "Bar".to_string(),
-                        field: String::new(),
+                    .map_err(|unknown_val| DecodeError::InvalidEnumValueError {
+                        obj: "Bar",
+                        field: "",
                         value: unknown_val as u64,
-                        type_: "Foo".to_string(),
+                        type_: "Foo",
                     })
             })
-            .collect::<Result<Vec<_>>>()?
+            .collect::<Result<Vec<_>, DecodeError>>()?
             .try_into()
-            .map_err(|_| Error::InvalidPacketError)?;
+            .map_err(|_| DecodeError::InvalidPacketError)?;
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         for elem in &self.x {
             buffer.put_uint(u32::from(elem) as u64, 3);
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -125,42 +126,42 @@ impl BarData {
     }
 }
 impl Packet for Bar {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.bar.get_size());
-        self.bar.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.bar.write_to(buf)
     }
 }
-impl From<Bar> for Bytes {
-    fn from(packet: Bar) -> Self {
-        packet.to_bytes()
+impl TryFrom<Bar> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Bar> for Vec<u8> {
-    fn from(packet: Bar) -> Self {
-        packet.to_vec()
+impl TryFrom<Bar> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Bar {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = BarData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(bar: BarData) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self, DecodeError> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> &[Foo; 5] {
         &self.bar.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.bar.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_24bit_enum_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_24bit_enum_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -28,7 +28,7 @@ pub enum Foo {
 }
 impl TryFrom<u32> for Foo {
     type Error = u32;
-    fn try_from(value: u32) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
         match value {
             0x1 => Ok(Foo::A),
             0x2 => Ok(Foo::B),
@@ -84,30 +84,31 @@ impl BarData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 3
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 3 {
-            return Err(Error::InvalidLengthError {
-                obj: "Bar".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Bar",
                 wanted: 3,
                 got: bytes.get().remaining(),
             });
         }
         let x = Foo::try_from(bytes.get_mut().get_uint(3) as u32)
-            .map_err(|unknown_val| Error::InvalidEnumValueError {
-                obj: "Bar".to_string(),
-                field: "x".to_string(),
+            .map_err(|unknown_val| DecodeError::InvalidEnumValueError {
+                obj: "Bar",
+                field: "x",
                 value: unknown_val as u64,
-                type_: "Foo".to_string(),
+                type_: "Foo",
             })?;
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         buffer.put_uint(u32::from(self.x) as u64, 3);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -117,42 +118,42 @@ impl BarData {
     }
 }
 impl Packet for Bar {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.bar.get_size());
-        self.bar.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.bar.write_to(buf)
     }
 }
-impl From<Bar> for Bytes {
-    fn from(packet: Bar) -> Self {
-        packet.to_bytes()
+impl TryFrom<Bar> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Bar> for Vec<u8> {
-    fn from(packet: Bar) -> Self {
-        packet.to_vec()
+impl TryFrom<Bar> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Bar {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = BarData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(bar: BarData) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self, DecodeError> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> Foo {
         self.bar.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.bar.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_24bit_enum_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_24bit_enum_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -28,7 +28,7 @@ pub enum Foo {
 }
 impl TryFrom<u32> for Foo {
     type Error = u32;
-    fn try_from(value: u32) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
         match value {
             0x1 => Ok(Foo::A),
             0x2 => Ok(Foo::B),
@@ -84,30 +84,31 @@ impl BarData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 3
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 3 {
-            return Err(Error::InvalidLengthError {
-                obj: "Bar".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Bar",
                 wanted: 3,
                 got: bytes.get().remaining(),
             });
         }
         let x = Foo::try_from(bytes.get_mut().get_uint_le(3) as u32)
-            .map_err(|unknown_val| Error::InvalidEnumValueError {
-                obj: "Bar".to_string(),
-                field: "x".to_string(),
+            .map_err(|unknown_val| DecodeError::InvalidEnumValueError {
+                obj: "Bar",
+                field: "x",
                 value: unknown_val as u64,
-                type_: "Foo".to_string(),
+                type_: "Foo",
             })?;
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         buffer.put_uint_le(u32::from(self.x) as u64, 3);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -117,42 +118,42 @@ impl BarData {
     }
 }
 impl Packet for Bar {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.bar.get_size());
-        self.bar.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.bar.write_to(buf)
     }
 }
-impl From<Bar> for Bytes {
-    fn from(packet: Bar) -> Self {
-        packet.to_bytes()
+impl TryFrom<Bar> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Bar> for Vec<u8> {
-    fn from(packet: Bar) -> Self {
-        packet.to_vec()
+impl TryFrom<Bar> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Bar {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = BarData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(bar: BarData) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self, DecodeError> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> Foo {
         self.bar.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.bar.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_24bit_scalar_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_24bit_scalar_array_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -38,30 +38,31 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 15
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 5 * 3 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 5 * 3,
                 got: bytes.get().remaining(),
             });
         }
         let x = (0..5)
-            .map(|_| Ok::<_, Error>(bytes.get_mut().get_uint(3) as u32))
-            .collect::<Result<Vec<_>>>()?
+            .map(|_| Ok::<_, DecodeError>(bytes.get_mut().get_uint(3) as u32))
+            .collect::<Result<Vec<_>, DecodeError>>()?
             .try_into()
-            .map_err(|_| Error::InvalidPacketError)?;
+            .map_err(|_| DecodeError::InvalidPacketError)?;
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         for elem in &self.x {
             buffer.put_uint(*elem as u64, 3);
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -71,42 +72,42 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> &[u32; 5] {
         &self.foo.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_24bit_scalar_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_24bit_scalar_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -38,15 +38,15 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 3
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 3 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 3,
                 got: bytes.get().remaining(),
             });
@@ -54,11 +54,17 @@ impl FooData {
         let x = bytes.get_mut().get_uint(3) as u32;
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if self.x > 0xff_ffff {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "x", self.x, 0xff_ffff);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "x",
+                value: self.x as u64,
+                maximum_value: 0xff_ffff,
+            });
         }
         buffer.put_uint(self.x as u64, 3);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -68,42 +74,42 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> u32 {
         self.foo.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_24bit_scalar_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_24bit_scalar_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -38,15 +38,15 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 3
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 3 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 3,
                 got: bytes.get().remaining(),
             });
@@ -54,11 +54,17 @@ impl FooData {
         let x = bytes.get_mut().get_uint_le(3) as u32;
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if self.x > 0xff_ffff {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "x", self.x, 0xff_ffff);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "x",
+                value: self.x as u64,
+                maximum_value: 0xff_ffff,
+            });
         }
         buffer.put_uint_le(self.x as u64, 3);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -68,42 +74,42 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> u32 {
         self.foo.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_64bit_enum_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_enum_array_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -28,7 +28,7 @@ pub enum Foo {
 }
 impl TryFrom<u64> for Foo {
     type Error = u64;
-    fn try_from(value: u64) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
         match value {
             0x1 => Ok(Foo::FooBar),
             0x2 => Ok(Foo::Baz),
@@ -69,15 +69,15 @@ impl BarData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 56
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 7 * 8 {
-            return Err(Error::InvalidLengthError {
-                obj: "Bar".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Bar",
                 wanted: 7 * 8,
                 got: bytes.get().remaining(),
             });
@@ -85,22 +85,23 @@ impl BarData {
         let x = (0..7)
             .map(|_| {
                 Foo::try_from(bytes.get_mut().get_u64())
-                    .map_err(|unknown_val| Error::InvalidEnumValueError {
-                        obj: "Bar".to_string(),
-                        field: String::new(),
+                    .map_err(|unknown_val| DecodeError::InvalidEnumValueError {
+                        obj: "Bar",
+                        field: "",
                         value: unknown_val as u64,
-                        type_: "Foo".to_string(),
+                        type_: "Foo",
                     })
             })
-            .collect::<Result<Vec<_>>>()?
+            .collect::<Result<Vec<_>, DecodeError>>()?
             .try_into()
-            .map_err(|_| Error::InvalidPacketError)?;
+            .map_err(|_| DecodeError::InvalidPacketError)?;
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         for elem in &self.x {
             buffer.put_u64(u64::from(elem));
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -110,42 +111,42 @@ impl BarData {
     }
 }
 impl Packet for Bar {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.bar.get_size());
-        self.bar.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.bar.write_to(buf)
     }
 }
-impl From<Bar> for Bytes {
-    fn from(packet: Bar) -> Self {
-        packet.to_bytes()
+impl TryFrom<Bar> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Bar> for Vec<u8> {
-    fn from(packet: Bar) -> Self {
-        packet.to_vec()
+impl TryFrom<Bar> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Bar {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = BarData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(bar: BarData) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self, DecodeError> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> &[Foo; 7] {
         &self.bar.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.bar.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_64bit_enum_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_enum_array_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -28,7 +28,7 @@ pub enum Foo {
 }
 impl TryFrom<u64> for Foo {
     type Error = u64;
-    fn try_from(value: u64) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
         match value {
             0x1 => Ok(Foo::FooBar),
             0x2 => Ok(Foo::Baz),
@@ -69,15 +69,15 @@ impl BarData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 56
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 7 * 8 {
-            return Err(Error::InvalidLengthError {
-                obj: "Bar".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Bar",
                 wanted: 7 * 8,
                 got: bytes.get().remaining(),
             });
@@ -85,22 +85,23 @@ impl BarData {
         let x = (0..7)
             .map(|_| {
                 Foo::try_from(bytes.get_mut().get_u64_le())
-                    .map_err(|unknown_val| Error::InvalidEnumValueError {
-                        obj: "Bar".to_string(),
-                        field: String::new(),
+                    .map_err(|unknown_val| DecodeError::InvalidEnumValueError {
+                        obj: "Bar",
+                        field: "",
                         value: unknown_val as u64,
-                        type_: "Foo".to_string(),
+                        type_: "Foo",
                     })
             })
-            .collect::<Result<Vec<_>>>()?
+            .collect::<Result<Vec<_>, DecodeError>>()?
             .try_into()
-            .map_err(|_| Error::InvalidPacketError)?;
+            .map_err(|_| DecodeError::InvalidPacketError)?;
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         for elem in &self.x {
             buffer.put_u64_le(u64::from(elem));
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -110,42 +111,42 @@ impl BarData {
     }
 }
 impl Packet for Bar {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.bar.get_size());
-        self.bar.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.bar.write_to(buf)
     }
 }
-impl From<Bar> for Bytes {
-    fn from(packet: Bar) -> Self {
-        packet.to_bytes()
+impl TryFrom<Bar> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Bar> for Vec<u8> {
-    fn from(packet: Bar) -> Self {
-        packet.to_vec()
+impl TryFrom<Bar> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Bar {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = BarData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(bar: BarData) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self, DecodeError> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> &[Foo; 7] {
         &self.bar.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.bar.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_64bit_enum_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_enum_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -28,7 +28,7 @@ pub enum Foo {
 }
 impl TryFrom<u64> for Foo {
     type Error = u64;
-    fn try_from(value: u64) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
         match value {
             0x1 => Ok(Foo::A),
             0x2 => Ok(Foo::B),
@@ -69,30 +69,31 @@ impl BarData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 8
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 8 {
-            return Err(Error::InvalidLengthError {
-                obj: "Bar".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Bar",
                 wanted: 8,
                 got: bytes.get().remaining(),
             });
         }
         let x = Foo::try_from(bytes.get_mut().get_u64())
-            .map_err(|unknown_val| Error::InvalidEnumValueError {
-                obj: "Bar".to_string(),
-                field: "x".to_string(),
+            .map_err(|unknown_val| DecodeError::InvalidEnumValueError {
+                obj: "Bar",
+                field: "x",
                 value: unknown_val as u64,
-                type_: "Foo".to_string(),
+                type_: "Foo",
             })?;
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         buffer.put_u64(u64::from(self.x));
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -102,42 +103,42 @@ impl BarData {
     }
 }
 impl Packet for Bar {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.bar.get_size());
-        self.bar.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.bar.write_to(buf)
     }
 }
-impl From<Bar> for Bytes {
-    fn from(packet: Bar) -> Self {
-        packet.to_bytes()
+impl TryFrom<Bar> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Bar> for Vec<u8> {
-    fn from(packet: Bar) -> Self {
-        packet.to_vec()
+impl TryFrom<Bar> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Bar {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = BarData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(bar: BarData) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self, DecodeError> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> Foo {
         self.bar.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.bar.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_64bit_scalar_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_scalar_array_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -38,30 +38,31 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 56
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 7 * 8 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 7 * 8,
                 got: bytes.get().remaining(),
             });
         }
         let x = (0..7)
-            .map(|_| Ok::<_, Error>(bytes.get_mut().get_u64()))
-            .collect::<Result<Vec<_>>>()?
+            .map(|_| Ok::<_, DecodeError>(bytes.get_mut().get_u64()))
+            .collect::<Result<Vec<_>, DecodeError>>()?
             .try_into()
-            .map_err(|_| Error::InvalidPacketError)?;
+            .map_err(|_| DecodeError::InvalidPacketError)?;
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         for elem in &self.x {
             buffer.put_u64(*elem);
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -71,42 +72,42 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> &[u64; 7] {
         &self.foo.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_64bit_scalar_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_scalar_array_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -38,30 +38,31 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 56
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 7 * 8 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 7 * 8,
                 got: bytes.get().remaining(),
             });
         }
         let x = (0..7)
-            .map(|_| Ok::<_, Error>(bytes.get_mut().get_u64_le()))
-            .collect::<Result<Vec<_>>>()?
+            .map(|_| Ok::<_, DecodeError>(bytes.get_mut().get_u64_le()))
+            .collect::<Result<Vec<_>, DecodeError>>()?
             .try_into()
-            .map_err(|_| Error::InvalidPacketError)?;
+            .map_err(|_| DecodeError::InvalidPacketError)?;
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         for elem in &self.x {
             buffer.put_u64_le(*elem);
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -71,42 +72,42 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> &[u64; 7] {
         &self.foo.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_64bit_scalar_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_scalar_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -38,15 +38,15 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 8
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 8 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 8,
                 got: bytes.get().remaining(),
             });
@@ -54,8 +54,9 @@ impl FooData {
         let x = bytes.get_mut().get_u64();
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         buffer.put_u64(self.x);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -65,42 +66,42 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> u64 {
         self.foo.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_64bit_scalar_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_scalar_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -38,15 +38,15 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 8
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 8 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 8,
                 got: bytes.get().remaining(),
             });
@@ -54,8 +54,9 @@ impl FooData {
         let x = bytes.get_mut().get_u64_le();
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         buffer.put_u64_le(self.x);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -65,42 +66,42 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> u64 {
         self.foo.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_8bit_enum_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_enum_array_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -28,7 +28,7 @@ pub enum Foo {
 }
 impl TryFrom<u8> for Foo {
     type Error = u8;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x1 => Ok(Foo::FooBar),
             0x2 => Ok(Foo::Baz),
@@ -99,15 +99,15 @@ impl BarData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 3
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 3 {
-            return Err(Error::InvalidLengthError {
-                obj: "Bar".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Bar",
                 wanted: 3,
                 got: bytes.get().remaining(),
             });
@@ -115,22 +115,23 @@ impl BarData {
         let x = (0..3)
             .map(|_| {
                 Foo::try_from(bytes.get_mut().get_u8())
-                    .map_err(|unknown_val| Error::InvalidEnumValueError {
-                        obj: "Bar".to_string(),
-                        field: String::new(),
+                    .map_err(|unknown_val| DecodeError::InvalidEnumValueError {
+                        obj: "Bar",
+                        field: "",
                         value: unknown_val as u64,
-                        type_: "Foo".to_string(),
+                        type_: "Foo",
                     })
             })
-            .collect::<Result<Vec<_>>>()?
+            .collect::<Result<Vec<_>, DecodeError>>()?
             .try_into()
-            .map_err(|_| Error::InvalidPacketError)?;
+            .map_err(|_| DecodeError::InvalidPacketError)?;
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         for elem in &self.x {
             buffer.put_u8(u8::from(elem));
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -140,42 +141,42 @@ impl BarData {
     }
 }
 impl Packet for Bar {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.bar.get_size());
-        self.bar.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.bar.write_to(buf)
     }
 }
-impl From<Bar> for Bytes {
-    fn from(packet: Bar) -> Self {
-        packet.to_bytes()
+impl TryFrom<Bar> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Bar> for Vec<u8> {
-    fn from(packet: Bar) -> Self {
-        packet.to_vec()
+impl TryFrom<Bar> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Bar {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = BarData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(bar: BarData) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self, DecodeError> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> &[Foo; 3] {
         &self.bar.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.bar.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_8bit_enum_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_enum_array_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -28,7 +28,7 @@ pub enum Foo {
 }
 impl TryFrom<u8> for Foo {
     type Error = u8;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x1 => Ok(Foo::FooBar),
             0x2 => Ok(Foo::Baz),
@@ -99,15 +99,15 @@ impl BarData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 3
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 3 {
-            return Err(Error::InvalidLengthError {
-                obj: "Bar".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Bar",
                 wanted: 3,
                 got: bytes.get().remaining(),
             });
@@ -115,22 +115,23 @@ impl BarData {
         let x = (0..3)
             .map(|_| {
                 Foo::try_from(bytes.get_mut().get_u8())
-                    .map_err(|unknown_val| Error::InvalidEnumValueError {
-                        obj: "Bar".to_string(),
-                        field: String::new(),
+                    .map_err(|unknown_val| DecodeError::InvalidEnumValueError {
+                        obj: "Bar",
+                        field: "",
                         value: unknown_val as u64,
-                        type_: "Foo".to_string(),
+                        type_: "Foo",
                     })
             })
-            .collect::<Result<Vec<_>>>()?
+            .collect::<Result<Vec<_>, DecodeError>>()?
             .try_into()
-            .map_err(|_| Error::InvalidPacketError)?;
+            .map_err(|_| DecodeError::InvalidPacketError)?;
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         for elem in &self.x {
             buffer.put_u8(u8::from(elem));
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -140,42 +141,42 @@ impl BarData {
     }
 }
 impl Packet for Bar {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.bar.get_size());
-        self.bar.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.bar.write_to(buf)
     }
 }
-impl From<Bar> for Bytes {
-    fn from(packet: Bar) -> Self {
-        packet.to_bytes()
+impl TryFrom<Bar> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Bar> for Vec<u8> {
-    fn from(packet: Bar) -> Self {
-        packet.to_vec()
+impl TryFrom<Bar> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Bar {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = BarData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(bar: BarData) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self, DecodeError> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> &[Foo; 3] {
         &self.bar.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.bar.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_8bit_enum_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_enum_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -28,7 +28,7 @@ pub enum Foo {
 }
 impl TryFrom<u8> for Foo {
     type Error = u8;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x1 => Ok(Foo::A),
             0x2 => Ok(Foo::B),
@@ -99,30 +99,31 @@ impl BarData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 1
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 1 {
-            return Err(Error::InvalidLengthError {
-                obj: "Bar".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Bar",
                 wanted: 1,
                 got: bytes.get().remaining(),
             });
         }
         let x = Foo::try_from(bytes.get_mut().get_u8())
-            .map_err(|unknown_val| Error::InvalidEnumValueError {
-                obj: "Bar".to_string(),
-                field: "x".to_string(),
+            .map_err(|unknown_val| DecodeError::InvalidEnumValueError {
+                obj: "Bar",
+                field: "x",
                 value: unknown_val as u64,
-                type_: "Foo".to_string(),
+                type_: "Foo",
             })?;
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         buffer.put_u8(u8::from(self.x));
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -132,42 +133,42 @@ impl BarData {
     }
 }
 impl Packet for Bar {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.bar.get_size());
-        self.bar.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.bar.write_to(buf)
     }
 }
-impl From<Bar> for Bytes {
-    fn from(packet: Bar) -> Self {
-        packet.to_bytes()
+impl TryFrom<Bar> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Bar> for Vec<u8> {
-    fn from(packet: Bar) -> Self {
-        packet.to_vec()
+impl TryFrom<Bar> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Bar {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = BarData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(bar: BarData) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self, DecodeError> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> Foo {
         self.bar.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.bar.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_8bit_enum_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_enum_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -28,7 +28,7 @@ pub enum Foo {
 }
 impl TryFrom<u8> for Foo {
     type Error = u8;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x1 => Ok(Foo::A),
             0x2 => Ok(Foo::B),
@@ -99,30 +99,31 @@ impl BarData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 1
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 1 {
-            return Err(Error::InvalidLengthError {
-                obj: "Bar".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Bar",
                 wanted: 1,
                 got: bytes.get().remaining(),
             });
         }
         let x = Foo::try_from(bytes.get_mut().get_u8())
-            .map_err(|unknown_val| Error::InvalidEnumValueError {
-                obj: "Bar".to_string(),
-                field: "x".to_string(),
+            .map_err(|unknown_val| DecodeError::InvalidEnumValueError {
+                obj: "Bar",
+                field: "x",
                 value: unknown_val as u64,
-                type_: "Foo".to_string(),
+                type_: "Foo",
             })?;
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         buffer.put_u8(u8::from(self.x));
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -132,42 +133,42 @@ impl BarData {
     }
 }
 impl Packet for Bar {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.bar.get_size());
-        self.bar.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.bar.write_to(buf)
     }
 }
-impl From<Bar> for Bytes {
-    fn from(packet: Bar) -> Self {
-        packet.to_bytes()
+impl TryFrom<Bar> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Bar> for Vec<u8> {
-    fn from(packet: Bar) -> Self {
-        packet.to_vec()
+impl TryFrom<Bar> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Bar {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = BarData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(bar: BarData) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self, DecodeError> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> Foo {
         self.bar.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.bar.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_8bit_scalar_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_scalar_array_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -38,30 +38,31 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 3
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 3 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 3,
                 got: bytes.get().remaining(),
             });
         }
         let x = (0..3)
-            .map(|_| Ok::<_, Error>(bytes.get_mut().get_u8()))
-            .collect::<Result<Vec<_>>>()?
+            .map(|_| Ok::<_, DecodeError>(bytes.get_mut().get_u8()))
+            .collect::<Result<Vec<_>, DecodeError>>()?
             .try_into()
-            .map_err(|_| Error::InvalidPacketError)?;
+            .map_err(|_| DecodeError::InvalidPacketError)?;
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         for elem in &self.x {
             buffer.put_u8(*elem);
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -71,42 +72,42 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> &[u8; 3] {
         &self.foo.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_8bit_scalar_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_scalar_array_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -38,30 +38,31 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 3
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 3 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 3,
                 got: bytes.get().remaining(),
             });
         }
         let x = (0..3)
-            .map(|_| Ok::<_, Error>(bytes.get_mut().get_u8()))
-            .collect::<Result<Vec<_>>>()?
+            .map(|_| Ok::<_, DecodeError>(bytes.get_mut().get_u8()))
+            .collect::<Result<Vec<_>, DecodeError>>()?
             .try_into()
-            .map_err(|_| Error::InvalidPacketError)?;
+            .map_err(|_| DecodeError::InvalidPacketError)?;
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         for elem in &self.x {
             buffer.put_u8(*elem);
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -71,42 +72,42 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> &[u8; 3] {
         &self.foo.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_8bit_scalar_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_scalar_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -38,15 +38,15 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 1
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 1 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 1,
                 got: bytes.get().remaining(),
             });
@@ -54,8 +54,9 @@ impl FooData {
         let x = bytes.get_mut().get_u8();
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         buffer.put_u8(self.x);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -65,42 +66,42 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> u8 {
         self.foo.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_8bit_scalar_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_scalar_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -38,15 +38,15 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 1
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 1 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 1,
                 got: bytes.get().remaining(),
             });
@@ -54,8 +54,9 @@ impl FooData {
         let x = bytes.get_mut().get_u8();
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         buffer.put_u8(self.x);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -65,42 +66,42 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> u8 {
         self.foo.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_array_dynamic_count_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_dynamic_count_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -40,15 +40,15 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 1
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 1 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 1,
                 got: bytes.get().remaining(),
             });
@@ -57,31 +57,40 @@ impl FooData {
         let x_count = (chunk & 0x1f) as usize;
         let padding = ((chunk >> 5) & 0x7);
         if bytes.get().remaining() < x_count * 3usize {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: x_count * 3usize,
                 got: bytes.get().remaining(),
             });
         }
         let x = (0..x_count)
-            .map(|_| Ok::<_, Error>(bytes.get_mut().get_uint_le(3) as u32))
-            .collect::<Result<Vec<_>>>()?;
+            .map(|_| Ok::<_, DecodeError>(bytes.get_mut().get_uint_le(3) as u32))
+            .collect::<Result<Vec<_>, DecodeError>>()?;
         Ok(Self { padding, x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if self.x.len() > 0x1f {
-            panic!("Invalid length for {}::{}: {} > {}", "Foo", "x", self.x.len(), 0x1f);
+            return Err(EncodeError::CountOverflow {
+                packet: "Foo",
+                field: "x",
+                count: self.x.len(),
+                maximum_count: 0x1f,
+            });
         }
         if self.padding > 0x7 {
-            panic!(
-                "Invalid value for {}::{}: {} > {}", "Foo", "padding", self.padding, 0x7
-            );
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "padding",
+                value: self.padding as u64,
+                maximum_value: 0x7,
+            });
         }
         let value = self.x.len() as u8 | (self.padding << 5);
         buffer.put_u8(value);
         for elem in &self.x {
             buffer.put_uint_le(*elem as u64, 3);
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -91,36 +100,36 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_padding(&self) -> u8 {
@@ -129,7 +138,7 @@ impl Foo {
     pub fn get_x(&self) -> &Vec<u32> {
         &self.foo.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_array_dynamic_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_dynamic_size_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -40,15 +40,15 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 1
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 1 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 1,
                 got: bytes.get().remaining(),
             });
@@ -57,14 +57,14 @@ impl FooData {
         let x_size = (chunk & 0x1f) as usize;
         let padding = ((chunk >> 5) & 0x7);
         if bytes.get().remaining() < x_size {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: x_size,
                 got: bytes.get().remaining(),
             });
         }
         if x_size % 3 != 0 {
-            return Err(Error::InvalidArraySize {
+            return Err(DecodeError::InvalidArraySize {
                 array: x_size,
                 element: 3,
             });
@@ -72,27 +72,33 @@ impl FooData {
         let x_count = x_size / 3;
         let mut x = Vec::with_capacity(x_count);
         for _ in 0..x_count {
-            x.push(Ok::<_, Error>(bytes.get_mut().get_uint(3) as u32)?);
+            x.push(Ok::<_, DecodeError>(bytes.get_mut().get_uint(3) as u32)?);
         }
         Ok(Self { padding, x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if (self.x.len() * 3) > 0x1f {
-            panic!(
-                "Invalid length for {}::{}: {} > {}", "Foo", "x", (self.x.len() * 3),
-                0x1f
-            );
+            return Err(EncodeError::SizeOverflow {
+                packet: "Foo",
+                field: "x",
+                size: (self.x.len() * 3),
+                maximum_size: 0x1f,
+            });
         }
         if self.padding > 0x7 {
-            panic!(
-                "Invalid value for {}::{}: {} > {}", "Foo", "padding", self.padding, 0x7
-            );
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "padding",
+                value: self.padding as u64,
+                maximum_value: 0x7,
+            });
         }
         let value = (self.x.len() * 3) as u8 | (self.padding << 5);
         buffer.put_u8(value);
         for elem in &self.x {
             buffer.put_uint(*elem as u64, 3);
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -102,36 +108,36 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_padding(&self) -> u8 {
@@ -140,7 +146,7 @@ impl Foo {
     pub fn get_x(&self) -> &Vec<u32> {
         &self.foo.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_array_dynamic_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_dynamic_size_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -40,15 +40,15 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 1
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 1 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 1,
                 got: bytes.get().remaining(),
             });
@@ -57,14 +57,14 @@ impl FooData {
         let x_size = (chunk & 0x1f) as usize;
         let padding = ((chunk >> 5) & 0x7);
         if bytes.get().remaining() < x_size {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: x_size,
                 got: bytes.get().remaining(),
             });
         }
         if x_size % 3 != 0 {
-            return Err(Error::InvalidArraySize {
+            return Err(DecodeError::InvalidArraySize {
                 array: x_size,
                 element: 3,
             });
@@ -72,27 +72,33 @@ impl FooData {
         let x_count = x_size / 3;
         let mut x = Vec::with_capacity(x_count);
         for _ in 0..x_count {
-            x.push(Ok::<_, Error>(bytes.get_mut().get_uint_le(3) as u32)?);
+            x.push(Ok::<_, DecodeError>(bytes.get_mut().get_uint_le(3) as u32)?);
         }
         Ok(Self { padding, x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if (self.x.len() * 3) > 0x1f {
-            panic!(
-                "Invalid length for {}::{}: {} > {}", "Foo", "x", (self.x.len() * 3),
-                0x1f
-            );
+            return Err(EncodeError::SizeOverflow {
+                packet: "Foo",
+                field: "x",
+                size: (self.x.len() * 3),
+                maximum_size: 0x1f,
+            });
         }
         if self.padding > 0x7 {
-            panic!(
-                "Invalid value for {}::{}: {} > {}", "Foo", "padding", self.padding, 0x7
-            );
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "padding",
+                value: self.padding as u64,
+                maximum_value: 0x7,
+            });
         }
         let value = (self.x.len() * 3) as u8 | (self.padding << 5);
         buffer.put_u8(value);
         for elem in &self.x {
             buffer.put_uint_le(*elem as u64, 3);
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -102,36 +108,36 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_padding(&self) -> u8 {
@@ -140,7 +146,7 @@ impl Foo {
     pub fn get_x(&self) -> &Vec<u32> {
         &self.foo.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_count_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_count_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -27,43 +27,46 @@ impl Foo {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 5
     }
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 5 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 5,
                 got: bytes.get().remaining(),
             });
         }
         let a_count = bytes.get_mut().get_uint(5) as usize;
         if bytes.get().remaining() < a_count * 2usize {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: a_count * 2usize,
                 got: bytes.get().remaining(),
             });
         }
         let a = (0..a_count)
-            .map(|_| Ok::<_, Error>(bytes.get_mut().get_u16()))
-            .collect::<Result<Vec<_>>>()?;
+            .map(|_| Ok::<_, DecodeError>(bytes.get_mut().get_u16()))
+            .collect::<Result<Vec<_>, DecodeError>>()?;
         Ok(Self { a })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if self.a.len() > 0xff_ffff_ffff_usize {
-            panic!(
-                "Invalid length for {}::{}: {} > {}", "Foo", "a", self.a.len(),
-                0xff_ffff_ffff_usize
-            );
+            return Err(EncodeError::CountOverflow {
+                packet: "Foo",
+                field: "a",
+                count: self.a.len(),
+                maximum_count: 0xff_ffff_ffff_usize,
+            });
         }
         buffer.put_uint(self.a.len() as u64, 5);
         for elem in &self.a {
             buffer.put_u16(*elem);
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -92,15 +95,15 @@ impl BarData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 5
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 5 {
-            return Err(Error::InvalidLengthError {
-                obj: "Bar".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Bar",
                 wanted: 5,
                 got: bytes.get().remaining(),
             });
@@ -108,20 +111,23 @@ impl BarData {
         let x_count = bytes.get_mut().get_uint(5) as usize;
         let x = (0..x_count)
             .map(|_| Foo::parse_inner(bytes))
-            .collect::<Result<Vec<_>>>()?;
+            .collect::<Result<Vec<_>, DecodeError>>()?;
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if self.x.len() > 0xff_ffff_ffff_usize {
-            panic!(
-                "Invalid length for {}::{}: {} > {}", "Bar", "x", self.x.len(),
-                0xff_ffff_ffff_usize
-            );
+            return Err(EncodeError::CountOverflow {
+                packet: "Bar",
+                field: "x",
+                count: self.x.len(),
+                maximum_count: 0xff_ffff_ffff_usize,
+            });
         }
         buffer.put_uint(self.x.len() as u64, 5);
         for elem in &self.x {
-            elem.write_to(buffer);
+            elem.write_to(buffer)?;
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -131,42 +137,42 @@ impl BarData {
     }
 }
 impl Packet for Bar {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.bar.get_size());
-        self.bar.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.bar.write_to(buf)
     }
 }
-impl From<Bar> for Bytes {
-    fn from(packet: Bar) -> Self {
-        packet.to_bytes()
+impl TryFrom<Bar> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Bar> for Vec<u8> {
-    fn from(packet: Bar) -> Self {
-        packet.to_vec()
+impl TryFrom<Bar> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Bar {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = BarData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(bar: BarData) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self, DecodeError> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> &Vec<Foo> {
         &self.bar.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.bar.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_count_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_count_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -27,43 +27,46 @@ impl Foo {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 5
     }
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 5 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 5,
                 got: bytes.get().remaining(),
             });
         }
         let a_count = bytes.get_mut().get_uint_le(5) as usize;
         if bytes.get().remaining() < a_count * 2usize {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: a_count * 2usize,
                 got: bytes.get().remaining(),
             });
         }
         let a = (0..a_count)
-            .map(|_| Ok::<_, Error>(bytes.get_mut().get_u16_le()))
-            .collect::<Result<Vec<_>>>()?;
+            .map(|_| Ok::<_, DecodeError>(bytes.get_mut().get_u16_le()))
+            .collect::<Result<Vec<_>, DecodeError>>()?;
         Ok(Self { a })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if self.a.len() > 0xff_ffff_ffff_usize {
-            panic!(
-                "Invalid length for {}::{}: {} > {}", "Foo", "a", self.a.len(),
-                0xff_ffff_ffff_usize
-            );
+            return Err(EncodeError::CountOverflow {
+                packet: "Foo",
+                field: "a",
+                count: self.a.len(),
+                maximum_count: 0xff_ffff_ffff_usize,
+            });
         }
         buffer.put_uint_le(self.a.len() as u64, 5);
         for elem in &self.a {
             buffer.put_u16_le(*elem);
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -92,15 +95,15 @@ impl BarData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 5
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 5 {
-            return Err(Error::InvalidLengthError {
-                obj: "Bar".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Bar",
                 wanted: 5,
                 got: bytes.get().remaining(),
             });
@@ -108,20 +111,23 @@ impl BarData {
         let x_count = bytes.get_mut().get_uint_le(5) as usize;
         let x = (0..x_count)
             .map(|_| Foo::parse_inner(bytes))
-            .collect::<Result<Vec<_>>>()?;
+            .collect::<Result<Vec<_>, DecodeError>>()?;
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if self.x.len() > 0xff_ffff_ffff_usize {
-            panic!(
-                "Invalid length for {}::{}: {} > {}", "Bar", "x", self.x.len(),
-                0xff_ffff_ffff_usize
-            );
+            return Err(EncodeError::CountOverflow {
+                packet: "Bar",
+                field: "x",
+                count: self.x.len(),
+                maximum_count: 0xff_ffff_ffff_usize,
+            });
         }
         buffer.put_uint_le(self.x.len() as u64, 5);
         for elem in &self.x {
-            elem.write_to(buffer);
+            elem.write_to(buffer)?;
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -131,42 +137,42 @@ impl BarData {
     }
 }
 impl Packet for Bar {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.bar.get_size());
-        self.bar.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.bar.write_to(buf)
     }
 }
-impl From<Bar> for Bytes {
-    fn from(packet: Bar) -> Self {
-        packet.to_bytes()
+impl TryFrom<Bar> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Bar> for Vec<u8> {
-    fn from(packet: Bar) -> Self {
-        packet.to_vec()
+impl TryFrom<Bar> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Bar {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = BarData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(bar: BarData) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self, DecodeError> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> &Vec<Foo> {
         &self.bar.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.bar.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_size_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -27,43 +27,46 @@ impl Foo {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 5
     }
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 5 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 5,
                 got: bytes.get().remaining(),
             });
         }
         let a_count = bytes.get_mut().get_uint(5) as usize;
         if bytes.get().remaining() < a_count * 2usize {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: a_count * 2usize,
                 got: bytes.get().remaining(),
             });
         }
         let a = (0..a_count)
-            .map(|_| Ok::<_, Error>(bytes.get_mut().get_u16()))
-            .collect::<Result<Vec<_>>>()?;
+            .map(|_| Ok::<_, DecodeError>(bytes.get_mut().get_u16()))
+            .collect::<Result<Vec<_>, DecodeError>>()?;
         Ok(Self { a })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if self.a.len() > 0xff_ffff_ffff_usize {
-            panic!(
-                "Invalid length for {}::{}: {} > {}", "Foo", "a", self.a.len(),
-                0xff_ffff_ffff_usize
-            );
+            return Err(EncodeError::CountOverflow {
+                packet: "Foo",
+                field: "a",
+                count: self.a.len(),
+                maximum_count: 0xff_ffff_ffff_usize,
+            });
         }
         buffer.put_uint(self.a.len() as u64, 5);
         for elem in &self.a {
             buffer.put_u16(*elem);
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -92,23 +95,23 @@ impl BarData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 5
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 5 {
-            return Err(Error::InvalidLengthError {
-                obj: "Bar".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Bar",
                 wanted: 5,
                 got: bytes.get().remaining(),
             });
         }
         let x_size = bytes.get_mut().get_uint(5) as usize;
         if bytes.get().remaining() < x_size {
-            return Err(Error::InvalidLengthError {
-                obj: "Bar".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Bar",
                 wanted: x_size,
                 got: bytes.get().remaining(),
             });
@@ -122,18 +125,21 @@ impl BarData {
         }
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         let x_size = self.x.iter().map(|elem| elem.get_size()).sum::<usize>();
         if x_size > 0xff_ffff_ffff_usize {
-            panic!(
-                "Invalid length for {}::{}: {} > {}", "Bar", "x", x_size,
-                0xff_ffff_ffff_usize
-            );
+            return Err(EncodeError::SizeOverflow {
+                packet: "Bar",
+                field: "x",
+                size: x_size,
+                maximum_size: 0xff_ffff_ffff_usize,
+            });
         }
         buffer.put_uint(x_size as u64, 5);
         for elem in &self.x {
-            elem.write_to(buffer);
+            elem.write_to(buffer)?;
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -143,42 +149,42 @@ impl BarData {
     }
 }
 impl Packet for Bar {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.bar.get_size());
-        self.bar.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.bar.write_to(buf)
     }
 }
-impl From<Bar> for Bytes {
-    fn from(packet: Bar) -> Self {
-        packet.to_bytes()
+impl TryFrom<Bar> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Bar> for Vec<u8> {
-    fn from(packet: Bar) -> Self {
-        packet.to_vec()
+impl TryFrom<Bar> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Bar {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = BarData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(bar: BarData) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self, DecodeError> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> &Vec<Foo> {
         &self.bar.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.bar.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_size_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -27,43 +27,46 @@ impl Foo {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 5
     }
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 5 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 5,
                 got: bytes.get().remaining(),
             });
         }
         let a_count = bytes.get_mut().get_uint_le(5) as usize;
         if bytes.get().remaining() < a_count * 2usize {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: a_count * 2usize,
                 got: bytes.get().remaining(),
             });
         }
         let a = (0..a_count)
-            .map(|_| Ok::<_, Error>(bytes.get_mut().get_u16_le()))
-            .collect::<Result<Vec<_>>>()?;
+            .map(|_| Ok::<_, DecodeError>(bytes.get_mut().get_u16_le()))
+            .collect::<Result<Vec<_>, DecodeError>>()?;
         Ok(Self { a })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if self.a.len() > 0xff_ffff_ffff_usize {
-            panic!(
-                "Invalid length for {}::{}: {} > {}", "Foo", "a", self.a.len(),
-                0xff_ffff_ffff_usize
-            );
+            return Err(EncodeError::CountOverflow {
+                packet: "Foo",
+                field: "a",
+                count: self.a.len(),
+                maximum_count: 0xff_ffff_ffff_usize,
+            });
         }
         buffer.put_uint_le(self.a.len() as u64, 5);
         for elem in &self.a {
             buffer.put_u16_le(*elem);
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -92,23 +95,23 @@ impl BarData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 5
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 5 {
-            return Err(Error::InvalidLengthError {
-                obj: "Bar".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Bar",
                 wanted: 5,
                 got: bytes.get().remaining(),
             });
         }
         let x_size = bytes.get_mut().get_uint_le(5) as usize;
         if bytes.get().remaining() < x_size {
-            return Err(Error::InvalidLengthError {
-                obj: "Bar".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Bar",
                 wanted: x_size,
                 got: bytes.get().remaining(),
             });
@@ -122,18 +125,21 @@ impl BarData {
         }
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         let x_size = self.x.iter().map(|elem| elem.get_size()).sum::<usize>();
         if x_size > 0xff_ffff_ffff_usize {
-            panic!(
-                "Invalid length for {}::{}: {} > {}", "Bar", "x", x_size,
-                0xff_ffff_ffff_usize
-            );
+            return Err(EncodeError::SizeOverflow {
+                packet: "Bar",
+                field: "x",
+                size: x_size,
+                maximum_size: 0xff_ffff_ffff_usize,
+            });
         }
         buffer.put_uint_le(x_size as u64, 5);
         for elem in &self.x {
-            elem.write_to(buffer);
+            elem.write_to(buffer)?;
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -143,42 +149,42 @@ impl BarData {
     }
 }
 impl Packet for Bar {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.bar.get_size());
-        self.bar.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.bar.write_to(buf)
     }
 }
-impl From<Bar> for Bytes {
-    fn from(packet: Bar) -> Self {
-        packet.to_bytes()
+impl TryFrom<Bar> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Bar> for Vec<u8> {
-    fn from(packet: Bar) -> Self {
-        packet.to_vec()
+impl TryFrom<Bar> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Bar {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = BarData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(bar: BarData) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self, DecodeError> {
         Ok(Self { bar })
     }
     pub fn get_x(&self) -> &Vec<Foo> {
         &self.bar.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.bar.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_array_with_padding_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_with_padding_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -27,43 +27,46 @@ impl Foo {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 5
     }
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 5 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 5,
                 got: bytes.get().remaining(),
             });
         }
         let a_count = bytes.get_mut().get_uint(5) as usize;
         if bytes.get().remaining() < a_count * 2usize {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: a_count * 2usize,
                 got: bytes.get().remaining(),
             });
         }
         let a = (0..a_count)
-            .map(|_| Ok::<_, Error>(bytes.get_mut().get_u16()))
-            .collect::<Result<Vec<_>>>()?;
+            .map(|_| Ok::<_, DecodeError>(bytes.get_mut().get_u16()))
+            .collect::<Result<Vec<_>, DecodeError>>()?;
         Ok(Self { a })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if self.a.len() > 0xff_ffff_ffff_usize {
-            panic!(
-                "Invalid length for {}::{}: {} > {}", "Foo", "a", self.a.len(),
-                0xff_ffff_ffff_usize
-            );
+            return Err(EncodeError::CountOverflow {
+                packet: "Foo",
+                field: "a",
+                count: self.a.len(),
+                maximum_count: 0xff_ffff_ffff_usize,
+            });
         }
         buffer.put_uint(self.a.len() as u64, 5);
         for elem in &self.a {
             buffer.put_u16(*elem);
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -92,15 +95,15 @@ impl BarData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 128
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 128usize {
-            return Err(Error::InvalidLengthError {
-                obj: "Bar".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Bar",
                 wanted: 128usize,
                 got: bytes.get().remaining(),
             });
@@ -114,18 +117,21 @@ impl BarData {
         }
         Ok(Self { a })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
-        let current_size = buffer.len();
-        for elem in &self.a {
-            elem.write_to(buffer);
-        }
-        let array_size = buffer.len() - current_size;
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
+        let array_size = self.a.iter().fold(0, |size, elem| size + elem.get_size());
         if array_size > 128usize {
-            panic!(
-                "attempted to serialize an array larger than the enclosing padding size"
-            );
+            return Err(EncodeError::SizeOverflow {
+                packet: "Bar",
+                field: "a",
+                size: array_size,
+                maximum_size: 128usize,
+            });
+        }
+        for elem in &self.a {
+            elem.write_to(buffer)?;
         }
         buffer.put_bytes(0, 128usize - array_size);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -135,42 +141,42 @@ impl BarData {
     }
 }
 impl Packet for Bar {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.bar.get_size());
-        self.bar.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.bar.write_to(buf)
     }
 }
-impl From<Bar> for Bytes {
-    fn from(packet: Bar) -> Self {
-        packet.to_bytes()
+impl TryFrom<Bar> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Bar> for Vec<u8> {
-    fn from(packet: Bar) -> Self {
-        packet.to_vec()
+impl TryFrom<Bar> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Bar {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = BarData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(bar: BarData) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self, DecodeError> {
         Ok(Self { bar })
     }
     pub fn get_a(&self) -> &Vec<Foo> {
         &self.bar.a
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.bar.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_array_with_padding_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_with_padding_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -27,43 +27,46 @@ impl Foo {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 5
     }
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 5 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 5,
                 got: bytes.get().remaining(),
             });
         }
         let a_count = bytes.get_mut().get_uint_le(5) as usize;
         if bytes.get().remaining() < a_count * 2usize {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: a_count * 2usize,
                 got: bytes.get().remaining(),
             });
         }
         let a = (0..a_count)
-            .map(|_| Ok::<_, Error>(bytes.get_mut().get_u16_le()))
-            .collect::<Result<Vec<_>>>()?;
+            .map(|_| Ok::<_, DecodeError>(bytes.get_mut().get_u16_le()))
+            .collect::<Result<Vec<_>, DecodeError>>()?;
         Ok(Self { a })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if self.a.len() > 0xff_ffff_ffff_usize {
-            panic!(
-                "Invalid length for {}::{}: {} > {}", "Foo", "a", self.a.len(),
-                0xff_ffff_ffff_usize
-            );
+            return Err(EncodeError::CountOverflow {
+                packet: "Foo",
+                field: "a",
+                count: self.a.len(),
+                maximum_count: 0xff_ffff_ffff_usize,
+            });
         }
         buffer.put_uint_le(self.a.len() as u64, 5);
         for elem in &self.a {
             buffer.put_u16_le(*elem);
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -92,15 +95,15 @@ impl BarData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 128
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 128usize {
-            return Err(Error::InvalidLengthError {
-                obj: "Bar".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Bar",
                 wanted: 128usize,
                 got: bytes.get().remaining(),
             });
@@ -114,18 +117,21 @@ impl BarData {
         }
         Ok(Self { a })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
-        let current_size = buffer.len();
-        for elem in &self.a {
-            elem.write_to(buffer);
-        }
-        let array_size = buffer.len() - current_size;
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
+        let array_size = self.a.iter().fold(0, |size, elem| size + elem.get_size());
         if array_size > 128usize {
-            panic!(
-                "attempted to serialize an array larger than the enclosing padding size"
-            );
+            return Err(EncodeError::SizeOverflow {
+                packet: "Bar",
+                field: "a",
+                size: array_size,
+                maximum_size: 128usize,
+            });
+        }
+        for elem in &self.a {
+            elem.write_to(buffer)?;
         }
         buffer.put_bytes(0, 128usize - array_size);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -135,42 +141,42 @@ impl BarData {
     }
 }
 impl Packet for Bar {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.bar.get_size());
-        self.bar.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.bar.write_to(buf)
     }
 }
-impl From<Bar> for Bytes {
-    fn from(packet: Bar) -> Self {
-        packet.to_bytes()
+impl TryFrom<Bar> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Bar> for Vec<u8> {
-    fn from(packet: Bar) -> Self {
-        packet.to_vec()
+impl TryFrom<Bar> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Bar {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = BarData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(bar: BarData) -> Result<Self> {
+    fn new(bar: BarData) -> Result<Self, DecodeError> {
         Ok(Self { bar })
     }
     pub fn get_a(&self) -> &Vec<Foo> {
         &self.bar.a
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.bar.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_child_packets_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_child_packets_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -28,7 +28,7 @@ pub enum Enum16 {
 }
 impl TryFrom<u16> for Enum16 {
     type Error = u16;
-    fn try_from(value: u16) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
         match value {
             0x1 => Ok(Enum16::A),
             0x2 => Ok(Enum16::B),
@@ -119,45 +119,45 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 4
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 1 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 1,
                 got: bytes.get().remaining(),
             });
         }
         let a = bytes.get_mut().get_u8();
         if bytes.get().remaining() < 2 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 2,
                 got: bytes.get().remaining(),
             });
         }
         let b = Enum16::try_from(bytes.get_mut().get_u16())
-            .map_err(|unknown_val| Error::InvalidEnumValueError {
-                obj: "Foo".to_string(),
-                field: "b".to_string(),
+            .map_err(|unknown_val| DecodeError::InvalidEnumValueError {
+                obj: "Foo",
+                field: "b",
                 value: unknown_val as u64,
-                type_: "Enum16".to_string(),
+                type_: "Enum16",
             })?;
         if bytes.get().remaining() < 1 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 1,
                 got: bytes.get().remaining(),
             });
         }
         let payload_size = bytes.get_mut().get_u8() as usize;
         if bytes.get().remaining() < payload_size {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: payload_size,
                 got: bytes.get().remaining(),
             });
@@ -182,22 +182,25 @@ impl FooData {
         };
         Ok(Self { a, b, child })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         buffer.put_u8(self.a);
         buffer.put_u16(u16::from(self.b));
         if self.child.get_total_size() > 0xff {
-            panic!(
-                "Invalid length for {}::{}: {} > {}", "Foo", "_payload_", self.child
-                .get_total_size(), 0xff
-            );
+            return Err(EncodeError::SizeOverflow {
+                packet: "Foo",
+                field: "_payload_",
+                size: self.child.get_total_size(),
+                maximum_size: 0xff,
+            });
         }
         buffer.put_u8(self.child.get_total_size() as u8);
         match &self.child {
-            FooDataChild::Bar(child) => child.write_to(buffer),
-            FooDataChild::Baz(child) => child.write_to(buffer),
+            FooDataChild::Bar(child) => child.write_to(buffer)?,
+            FooDataChild::Baz(child) => child.write_to(buffer)?,
             FooDataChild::Payload(payload) => buffer.put_slice(payload),
             FooDataChild::None => {}
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -207,32 +210,32 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
@@ -244,7 +247,7 @@ impl Foo {
             FooDataChild::None => FooChild::None,
         }
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_a(&self) -> u8 {
@@ -253,7 +256,7 @@ impl Foo {
     pub fn get_b(&self) -> Enum16 {
         self.foo.b
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {
@@ -301,15 +304,15 @@ impl BarData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 1
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 1 {
-            return Err(Error::InvalidLengthError {
-                obj: "Bar".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Bar",
                 wanted: 1,
                 got: bytes.get().remaining(),
             });
@@ -317,8 +320,9 @@ impl BarData {
         let x = bytes.get_mut().get_u8();
         Ok(Self { x })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         buffer.put_u8(self.x);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -328,23 +332,23 @@ impl BarData {
     }
 }
 impl Packet for Bar {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Bar> for Bytes {
-    fn from(packet: Bar) -> Self {
-        packet.to_bytes()
+impl TryFrom<Bar> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Bar> for Vec<u8> {
-    fn from(packet: Bar) -> Self {
-        packet.to_vec()
+impl TryFrom<Bar> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Bar) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl From<Bar> for Foo {
@@ -353,26 +357,26 @@ impl From<Bar> for Foo {
     }
 }
 impl TryFrom<Foo> for Bar {
-    type Error = Error;
-    fn try_from(packet: Foo) -> Result<Bar> {
+    type Error = DecodeError;
+    fn try_from(packet: Foo) -> Result<Bar, Self::Error> {
         Bar::new(packet.foo)
     }
 }
 impl Bar {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         let bar = match &foo.child {
             FooDataChild::Bar(value) => value.clone(),
             _ => {
-                return Err(Error::InvalidChildError {
+                return Err(DecodeError::InvalidChildError {
                     expected: stringify!(FooDataChild::Bar),
                     actual: format!("{:?}", & foo.child),
                 });
@@ -389,7 +393,7 @@ impl Bar {
     pub fn get_x(&self) -> u8 {
         self.bar.x
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.bar.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {
@@ -440,15 +444,15 @@ impl BazData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 2
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 2 {
-            return Err(Error::InvalidLengthError {
-                obj: "Baz".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Baz",
                 wanted: 2,
                 got: bytes.get().remaining(),
             });
@@ -456,8 +460,9 @@ impl BazData {
         let y = bytes.get_mut().get_u16();
         Ok(Self { y })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         buffer.put_u16(self.y);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -467,23 +472,23 @@ impl BazData {
     }
 }
 impl Packet for Baz {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Baz> for Bytes {
-    fn from(packet: Baz) -> Self {
-        packet.to_bytes()
+impl TryFrom<Baz> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Baz) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Baz> for Vec<u8> {
-    fn from(packet: Baz) -> Self {
-        packet.to_vec()
+impl TryFrom<Baz> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Baz) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl From<Baz> for Foo {
@@ -492,26 +497,26 @@ impl From<Baz> for Foo {
     }
 }
 impl TryFrom<Foo> for Baz {
-    type Error = Error;
-    fn try_from(packet: Foo) -> Result<Baz> {
+    type Error = DecodeError;
+    fn try_from(packet: Foo) -> Result<Baz, Self::Error> {
         Baz::new(packet.foo)
     }
 }
 impl Baz {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         let baz = match &foo.child {
             FooDataChild::Baz(value) => value.clone(),
             _ => {
-                return Err(Error::InvalidChildError {
+                return Err(DecodeError::InvalidChildError {
                     expected: stringify!(FooDataChild::Baz),
                     actual: format!("{:?}", & foo.child),
                 });
@@ -528,7 +533,7 @@ impl Baz {
     pub fn get_y(&self) -> u16 {
         self.baz.y
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.baz.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_complex_scalars_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_complex_scalars_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -48,15 +48,15 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 7
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 2 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 2,
                 got: bytes.get().remaining(),
             });
@@ -66,16 +66,16 @@ impl FooData {
         let b = (chunk >> 3) as u8;
         let c = ((chunk >> 11) & 0x1f) as u8;
         if bytes.get().remaining() < 3 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 3,
                 got: bytes.get().remaining(),
             });
         }
         let d = bytes.get_mut().get_uint(3) as u32;
         if bytes.get().remaining() < 2 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 2,
                 got: bytes.get().remaining(),
             });
@@ -85,27 +85,53 @@ impl FooData {
         let f = ((chunk >> 12) & 0xf) as u8;
         Ok(Self { a, b, c, d, e, f })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if self.a > 0x7 {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "a", self.a, 0x7);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "a",
+                value: self.a as u64,
+                maximum_value: 0x7,
+            });
         }
         if self.c > 0x1f {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "c", self.c, 0x1f);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "c",
+                value: self.c as u64,
+                maximum_value: 0x1f,
+            });
         }
         let value = (self.a as u16) | ((self.b as u16) << 3) | ((self.c as u16) << 11);
         buffer.put_u16(value);
         if self.d > 0xff_ffff {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "d", self.d, 0xff_ffff);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "d",
+                value: self.d as u64,
+                maximum_value: 0xff_ffff,
+            });
         }
         buffer.put_uint(self.d as u64, 3);
         if self.e > 0xfff {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "e", self.e, 0xfff);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "e",
+                value: self.e as u64,
+                maximum_value: 0xfff,
+            });
         }
         if self.f > 0xf {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "f", self.f, 0xf);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "f",
+                value: self.f as u64,
+                maximum_value: 0xf,
+            });
         }
         let value = self.e | ((self.f as u16) << 12);
         buffer.put_u16(value);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -115,36 +141,36 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_a(&self) -> u8 {
@@ -165,7 +191,7 @@ impl Foo {
     pub fn get_f(&self) -> u8 {
         self.foo.f
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_custom_field_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_custom_field_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -34,7 +34,7 @@ impl From<Bar1> for u32 {
 }
 impl TryFrom<u32> for Bar1 {
     type Error = u32;
-    fn try_from(value: u32) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
         if value > 0xff_ffff { Err(value) } else { Ok(Bar1(value)) }
     }
 }
@@ -79,19 +79,20 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 7
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let a = (bytes.get_mut().get_uint(3) as u32).try_into().unwrap();
         let b = bytes.get_mut().get_u32().into();
         Ok(Self { a, b })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         buffer.put_uint(u32::from(self.a) as u64, 3);
         buffer.put_u32(u32::from(self.b));
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -101,36 +102,36 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_a(&self) -> Bar1 {
@@ -139,7 +140,7 @@ impl Foo {
     pub fn get_b(&self) -> Bar2 {
         self.foo.b
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_empty_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_empty_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -34,15 +34,17 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         true
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         Ok(Self {})
     }
-    fn write_to(&self, buffer: &mut BytesMut) {}
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
+        Ok(())
+    }
     fn get_total_size(&self) -> usize {
         self.get_size()
     }
@@ -51,39 +53,39 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_empty_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_empty_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -34,15 +34,17 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         true
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         Ok(Self {})
     }
-    fn write_to(&self, buffer: &mut BytesMut) {}
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
+        Ok(())
+    }
     fn get_total_size(&self) -> usize {
         self.get_size()
     }
@@ -51,39 +53,39 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_fixed_enum_field_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_fixed_enum_field_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -28,7 +28,7 @@ pub enum Enum7 {
 }
 impl TryFrom<u8> for Enum7 {
     type Error = u8;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x1 => Ok(Enum7::A),
             0x2 => Ok(Enum7::B),
@@ -104,15 +104,15 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 8
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 8 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 8,
                 got: bytes.get().remaining(),
             });
@@ -120,7 +120,7 @@ impl FooData {
         let chunk = bytes.get_mut().get_u64();
         let fixed_value = (chunk & 0x7f) as u8;
         if fixed_value != u8::from(Enum7::A) {
-            return Err(Error::InvalidFixedValue {
+            return Err(DecodeError::InvalidFixedValue {
                 expected: u8::from(Enum7::A) as u64,
                 actual: fixed_value as u64,
             });
@@ -128,15 +128,18 @@ impl FooData {
         let b = ((chunk >> 7) & 0x1ff_ffff_ffff_ffff_u64);
         Ok(Self { b })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if self.b > 0x1ff_ffff_ffff_ffff_u64 {
-            panic!(
-                "Invalid value for {}::{}: {} > {}", "Foo", "b", self.b,
-                0x1ff_ffff_ffff_ffff_u64
-            );
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "b",
+                value: self.b as u64,
+                maximum_value: 0x1ff_ffff_ffff_ffff_u64,
+            });
         }
         let value = (u8::from(Enum7::A) as u64) | (self.b << 7);
         buffer.put_u64(value);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -146,42 +149,42 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_b(&self) -> u64 {
         self.foo.b
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_fixed_enum_field_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_fixed_enum_field_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -28,7 +28,7 @@ pub enum Enum7 {
 }
 impl TryFrom<u8> for Enum7 {
     type Error = u8;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x1 => Ok(Enum7::A),
             0x2 => Ok(Enum7::B),
@@ -104,15 +104,15 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 8
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 8 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 8,
                 got: bytes.get().remaining(),
             });
@@ -120,7 +120,7 @@ impl FooData {
         let chunk = bytes.get_mut().get_u64_le();
         let fixed_value = (chunk & 0x7f) as u8;
         if fixed_value != u8::from(Enum7::A) {
-            return Err(Error::InvalidFixedValue {
+            return Err(DecodeError::InvalidFixedValue {
                 expected: u8::from(Enum7::A) as u64,
                 actual: fixed_value as u64,
             });
@@ -128,15 +128,18 @@ impl FooData {
         let b = ((chunk >> 7) & 0x1ff_ffff_ffff_ffff_u64);
         Ok(Self { b })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if self.b > 0x1ff_ffff_ffff_ffff_u64 {
-            panic!(
-                "Invalid value for {}::{}: {} > {}", "Foo", "b", self.b,
-                0x1ff_ffff_ffff_ffff_u64
-            );
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "b",
+                value: self.b as u64,
+                maximum_value: 0x1ff_ffff_ffff_ffff_u64,
+            });
         }
         let value = (u8::from(Enum7::A) as u64) | (self.b << 7);
         buffer.put_u64_le(value);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -146,42 +149,42 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_b(&self) -> u64 {
         self.foo.b
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_fixed_scalar_field_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_fixed_scalar_field_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -38,15 +38,15 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 8
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 8 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 8,
                 got: bytes.get().remaining(),
             });
@@ -54,7 +54,7 @@ impl FooData {
         let chunk = bytes.get_mut().get_u64();
         let fixed_value = (chunk & 0x7f) as u8;
         if fixed_value != 7 {
-            return Err(Error::InvalidFixedValue {
+            return Err(DecodeError::InvalidFixedValue {
                 expected: 7,
                 actual: fixed_value as u64,
             });
@@ -62,15 +62,18 @@ impl FooData {
         let b = ((chunk >> 7) & 0x1ff_ffff_ffff_ffff_u64);
         Ok(Self { b })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if self.b > 0x1ff_ffff_ffff_ffff_u64 {
-            panic!(
-                "Invalid value for {}::{}: {} > {}", "Foo", "b", self.b,
-                0x1ff_ffff_ffff_ffff_u64
-            );
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "b",
+                value: self.b as u64,
+                maximum_value: 0x1ff_ffff_ffff_ffff_u64,
+            });
         }
         let value = (7 as u64) | (self.b << 7);
         buffer.put_u64(value);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -80,42 +83,42 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_b(&self) -> u64 {
         self.foo.b
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_grand_children_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_grand_children_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -28,7 +28,7 @@ pub enum Enum16 {
 }
 impl TryFrom<u16> for Enum16 {
     type Error = u16;
-    fn try_from(value: u16) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
         match value {
             0x1 => Ok(Enum16::A),
             0x2 => Ok(Enum16::B),
@@ -118,65 +118,65 @@ impl ParentData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 7
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 2 {
-            return Err(Error::InvalidLengthError {
-                obj: "Parent".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Parent",
                 wanted: 2,
                 got: bytes.get().remaining(),
             });
         }
         let foo = Enum16::try_from(bytes.get_mut().get_u16_le())
-            .map_err(|unknown_val| Error::InvalidEnumValueError {
-                obj: "Parent".to_string(),
-                field: "foo".to_string(),
+            .map_err(|unknown_val| DecodeError::InvalidEnumValueError {
+                obj: "Parent",
+                field: "foo",
                 value: unknown_val as u64,
-                type_: "Enum16".to_string(),
+                type_: "Enum16",
             })?;
         if bytes.get().remaining() < 2 {
-            return Err(Error::InvalidLengthError {
-                obj: "Parent".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Parent",
                 wanted: 2,
                 got: bytes.get().remaining(),
             });
         }
         let bar = Enum16::try_from(bytes.get_mut().get_u16_le())
-            .map_err(|unknown_val| Error::InvalidEnumValueError {
-                obj: "Parent".to_string(),
-                field: "bar".to_string(),
+            .map_err(|unknown_val| DecodeError::InvalidEnumValueError {
+                obj: "Parent",
+                field: "bar",
                 value: unknown_val as u64,
-                type_: "Enum16".to_string(),
+                type_: "Enum16",
             })?;
         if bytes.get().remaining() < 2 {
-            return Err(Error::InvalidLengthError {
-                obj: "Parent".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Parent",
                 wanted: 2,
                 got: bytes.get().remaining(),
             });
         }
         let baz = Enum16::try_from(bytes.get_mut().get_u16_le())
-            .map_err(|unknown_val| Error::InvalidEnumValueError {
-                obj: "Parent".to_string(),
-                field: "baz".to_string(),
+            .map_err(|unknown_val| DecodeError::InvalidEnumValueError {
+                obj: "Parent",
+                field: "baz",
                 value: unknown_val as u64,
-                type_: "Enum16".to_string(),
+                type_: "Enum16",
             })?;
         if bytes.get().remaining() < 1 {
-            return Err(Error::InvalidLengthError {
-                obj: "Parent".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Parent",
                 wanted: 1,
                 got: bytes.get().remaining(),
             });
         }
         let payload_size = bytes.get_mut().get_u8() as usize;
         if bytes.get().remaining() < payload_size {
-            return Err(Error::InvalidLengthError {
-                obj: "Parent".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Parent",
                 wanted: payload_size,
                 got: bytes.get().remaining(),
             });
@@ -196,22 +196,25 @@ impl ParentData {
         };
         Ok(Self { foo, bar, baz, child })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         buffer.put_u16_le(u16::from(self.foo));
         buffer.put_u16_le(u16::from(self.bar));
         buffer.put_u16_le(u16::from(self.baz));
         if self.child.get_total_size() > 0xff {
-            panic!(
-                "Invalid length for {}::{}: {} > {}", "Parent", "_payload_", self.child
-                .get_total_size(), 0xff
-            );
+            return Err(EncodeError::SizeOverflow {
+                packet: "Parent",
+                field: "_payload_",
+                size: self.child.get_total_size(),
+                maximum_size: 0xff,
+            });
         }
         buffer.put_u8(self.child.get_total_size() as u8);
         match &self.child {
-            ParentDataChild::Child(child) => child.write_to(buffer),
+            ParentDataChild::Child(child) => child.write_to(buffer)?,
             ParentDataChild::Payload(payload) => buffer.put_slice(payload),
             ParentDataChild::None => {}
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -221,32 +224,32 @@ impl ParentData {
     }
 }
 impl Packet for Parent {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.parent.get_size());
-        self.parent.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.parent.write_to(buf)
     }
 }
-impl From<Parent> for Bytes {
-    fn from(packet: Parent) -> Self {
-        packet.to_bytes()
+impl TryFrom<Parent> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Parent) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Parent> for Vec<u8> {
-    fn from(packet: Parent) -> Self {
-        packet.to_vec()
+impl TryFrom<Parent> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Parent) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Parent {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = ParentData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
@@ -259,7 +262,7 @@ impl Parent {
             ParentDataChild::None => ParentChild::None,
         }
     }
-    fn new(parent: ParentData) -> Result<Self> {
+    fn new(parent: ParentData) -> Result<Self, DecodeError> {
         Ok(Self { parent })
     }
     pub fn get_bar(&self) -> Enum16 {
@@ -271,7 +274,7 @@ impl Parent {
     pub fn get_foo(&self) -> Enum16 {
         self.parent.foo
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.parent.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {
@@ -346,7 +349,7 @@ impl ChildData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 2
     }
-    fn parse(bytes: &[u8], bar: Enum16, baz: Enum16) -> Result<Self> {
+    fn parse(bytes: &[u8], bar: Enum16, baz: Enum16) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell, bar, baz)?;
         Ok(packet)
@@ -355,20 +358,20 @@ impl ChildData {
         mut bytes: &mut Cell<&[u8]>,
         bar: Enum16,
         baz: Enum16,
-    ) -> Result<Self> {
+    ) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 2 {
-            return Err(Error::InvalidLengthError {
-                obj: "Child".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Child",
                 wanted: 2,
                 got: bytes.get().remaining(),
             });
         }
         let quux = Enum16::try_from(bytes.get_mut().get_u16_le())
-            .map_err(|unknown_val| Error::InvalidEnumValueError {
-                obj: "Child".to_string(),
-                field: "quux".to_string(),
+            .map_err(|unknown_val| DecodeError::InvalidEnumValueError {
+                obj: "Child",
+                field: "quux",
                 value: unknown_val as u64,
-                type_: "Enum16".to_string(),
+                type_: "Enum16",
             })?;
         let payload = bytes.get();
         bytes.get_mut().advance(payload.len());
@@ -385,13 +388,14 @@ impl ChildData {
         };
         Ok(Self { quux, child })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         buffer.put_u16_le(u16::from(self.quux));
         match &self.child {
-            ChildDataChild::GrandChild(child) => child.write_to(buffer),
+            ChildDataChild::GrandChild(child) => child.write_to(buffer)?,
             ChildDataChild::Payload(payload) => buffer.put_slice(payload),
             ChildDataChild::None => {}
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -401,23 +405,23 @@ impl ChildData {
     }
 }
 impl Packet for Child {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.parent.get_size());
-        self.parent.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.parent.write_to(buf)
     }
 }
-impl From<Child> for Bytes {
-    fn from(packet: Child) -> Self {
-        packet.to_bytes()
+impl TryFrom<Child> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Child) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Child> for Vec<u8> {
-    fn from(packet: Child) -> Self {
-        packet.to_vec()
+impl TryFrom<Child> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Child) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl From<Child> for Parent {
@@ -426,18 +430,18 @@ impl From<Child> for Parent {
     }
 }
 impl TryFrom<Parent> for Child {
-    type Error = Error;
-    fn try_from(packet: Parent) -> Result<Child> {
+    type Error = DecodeError;
+    fn try_from(packet: Parent) -> Result<Child, Self::Error> {
         Child::new(packet.parent)
     }
 }
 impl Child {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = ParentData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
@@ -450,11 +454,11 @@ impl Child {
             ChildDataChild::None => ChildChild::None,
         }
     }
-    fn new(parent: ParentData) -> Result<Self> {
+    fn new(parent: ParentData) -> Result<Self, DecodeError> {
         let child = match &parent.child {
             ParentDataChild::Child(value) => value.clone(),
             _ => {
-                return Err(Error::InvalidChildError {
+                return Err(DecodeError::InvalidChildError {
                     expected: stringify!(ParentDataChild::Child),
                     actual: format!("{:?}", & parent.child),
                 });
@@ -474,7 +478,7 @@ impl Child {
     pub fn get_quux(&self) -> Enum16 {
         self.child.quux
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.child.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {
@@ -557,12 +561,15 @@ impl GrandChildData {
     fn conforms(bytes: &[u8]) -> bool {
         true
     }
-    fn parse(bytes: &[u8], baz: Enum16) -> Result<Self> {
+    fn parse(bytes: &[u8], baz: Enum16) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell, baz)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>, baz: Enum16) -> Result<Self> {
+    fn parse_inner(
+        mut bytes: &mut Cell<&[u8]>,
+        baz: Enum16,
+    ) -> Result<Self, DecodeError> {
         let payload = bytes.get();
         bytes.get_mut().advance(payload.len());
         let child = match (baz) {
@@ -578,12 +585,13 @@ impl GrandChildData {
         };
         Ok(Self { child })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         match &self.child {
-            GrandChildDataChild::GrandGrandChild(child) => child.write_to(buffer),
+            GrandChildDataChild::GrandGrandChild(child) => child.write_to(buffer)?,
             GrandChildDataChild::Payload(payload) => buffer.put_slice(payload),
             GrandChildDataChild::None => {}
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -593,23 +601,23 @@ impl GrandChildData {
     }
 }
 impl Packet for GrandChild {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.parent.get_size());
-        self.parent.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.parent.write_to(buf)
     }
 }
-impl From<GrandChild> for Bytes {
-    fn from(packet: GrandChild) -> Self {
-        packet.to_bytes()
+impl TryFrom<GrandChild> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: GrandChild) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<GrandChild> for Vec<u8> {
-    fn from(packet: GrandChild) -> Self {
-        packet.to_vec()
+impl TryFrom<GrandChild> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: GrandChild) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl From<GrandChild> for Parent {
@@ -623,18 +631,18 @@ impl From<GrandChild> for Child {
     }
 }
 impl TryFrom<Parent> for GrandChild {
-    type Error = Error;
-    fn try_from(packet: Parent) -> Result<GrandChild> {
+    type Error = DecodeError;
+    fn try_from(packet: Parent) -> Result<GrandChild, Self::Error> {
         GrandChild::new(packet.parent)
     }
 }
 impl GrandChild {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = ParentData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
@@ -651,11 +659,11 @@ impl GrandChild {
             GrandChildDataChild::None => GrandChildChild::None,
         }
     }
-    fn new(parent: ParentData) -> Result<Self> {
+    fn new(parent: ParentData) -> Result<Self, DecodeError> {
         let child = match &parent.child {
             ParentDataChild::Child(value) => value.clone(),
             _ => {
-                return Err(Error::InvalidChildError {
+                return Err(DecodeError::InvalidChildError {
                     expected: stringify!(ParentDataChild::Child),
                     actual: format!("{:?}", & parent.child),
                 });
@@ -664,7 +672,7 @@ impl GrandChild {
         let grandchild = match &child.child {
             ChildDataChild::GrandChild(value) => value.clone(),
             _ => {
-                return Err(Error::InvalidChildError {
+                return Err(DecodeError::InvalidChildError {
                     expected: stringify!(ChildDataChild::GrandChild),
                     actual: format!("{:?}", & child.child),
                 });
@@ -684,7 +692,7 @@ impl GrandChild {
     pub fn get_quux(&self) -> Enum16 {
         self.child.quux
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.grandchild.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {
@@ -773,12 +781,12 @@ impl GrandGrandChildData {
     fn conforms(bytes: &[u8]) -> bool {
         true
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let payload = bytes.get();
         bytes.get_mut().advance(payload.len());
         let child = match () {
@@ -789,11 +797,12 @@ impl GrandGrandChildData {
         };
         Ok(Self { child })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         match &self.child {
             GrandGrandChildDataChild::Payload(payload) => buffer.put_slice(payload),
             GrandGrandChildDataChild::None => {}
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -803,23 +812,23 @@ impl GrandGrandChildData {
     }
 }
 impl Packet for GrandGrandChild {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.parent.get_size());
-        self.parent.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.parent.write_to(buf)
     }
 }
-impl From<GrandGrandChild> for Bytes {
-    fn from(packet: GrandGrandChild) -> Self {
-        packet.to_bytes()
+impl TryFrom<GrandGrandChild> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: GrandGrandChild) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<GrandGrandChild> for Vec<u8> {
-    fn from(packet: GrandGrandChild) -> Self {
-        packet.to_vec()
+impl TryFrom<GrandGrandChild> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: GrandGrandChild) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl From<GrandGrandChild> for Parent {
@@ -838,18 +847,18 @@ impl From<GrandGrandChild> for GrandChild {
     }
 }
 impl TryFrom<Parent> for GrandGrandChild {
-    type Error = Error;
-    fn try_from(packet: Parent) -> Result<GrandGrandChild> {
+    type Error = DecodeError;
+    fn try_from(packet: Parent) -> Result<GrandGrandChild, Self::Error> {
         GrandGrandChild::new(packet.parent)
     }
 }
 impl GrandGrandChild {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = ParentData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
@@ -861,11 +870,11 @@ impl GrandGrandChild {
             GrandGrandChildDataChild::None => GrandGrandChildChild::None,
         }
     }
-    fn new(parent: ParentData) -> Result<Self> {
+    fn new(parent: ParentData) -> Result<Self, DecodeError> {
         let child = match &parent.child {
             ParentDataChild::Child(value) => value.clone(),
             _ => {
-                return Err(Error::InvalidChildError {
+                return Err(DecodeError::InvalidChildError {
                     expected: stringify!(ParentDataChild::Child),
                     actual: format!("{:?}", & parent.child),
                 });
@@ -874,7 +883,7 @@ impl GrandGrandChild {
         let grandchild = match &child.child {
             ChildDataChild::GrandChild(value) => value.clone(),
             _ => {
-                return Err(Error::InvalidChildError {
+                return Err(DecodeError::InvalidChildError {
                     expected: stringify!(ChildDataChild::GrandChild),
                     actual: format!("{:?}", & child.child),
                 });
@@ -883,7 +892,7 @@ impl GrandGrandChild {
         let grandgrandchild = match &grandchild.child {
             GrandChildDataChild::GrandGrandChild(value) => value.clone(),
             _ => {
-                return Err(Error::InvalidChildError {
+                return Err(DecodeError::InvalidChildError {
                     expected: stringify!(GrandChildDataChild::GrandGrandChild),
                     actual: format!("{:?}", & grandchild.child),
                 });
@@ -914,7 +923,7 @@ impl GrandGrandChild {
             GrandGrandChildDataChild::None => &[],
         }
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.grandgrandchild.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_mask_scalar_value_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_mask_scalar_value_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -42,15 +42,15 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 4
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 4 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 4,
                 got: bytes.get().remaining(),
             });
@@ -61,18 +61,34 @@ impl FooData {
         let c = ((chunk >> 26) & 0x3f) as u8;
         Ok(Self { a, b, c })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if self.a > 0x3 {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "a", self.a, 0x3);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "a",
+                value: self.a as u64,
+                maximum_value: 0x3,
+            });
         }
         if self.b > 0xff_ffff {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "b", self.b, 0xff_ffff);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "b",
+                value: self.b as u64,
+                maximum_value: 0xff_ffff,
+            });
         }
         if self.c > 0x3f {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "c", self.c, 0x3f);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "c",
+                value: self.c as u64,
+                maximum_value: 0x3f,
+            });
         }
         let value = (self.a as u32) | (self.b << 2) | ((self.c as u32) << 26);
         buffer.put_u32(value);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -82,36 +98,36 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_a(&self) -> u8 {
@@ -123,7 +139,7 @@ impl Foo {
     pub fn get_c(&self) -> u8 {
         self.foo.c
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_mask_scalar_value_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_mask_scalar_value_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -42,15 +42,15 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 4
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 4 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 4,
                 got: bytes.get().remaining(),
             });
@@ -61,18 +61,34 @@ impl FooData {
         let c = ((chunk >> 26) & 0x3f) as u8;
         Ok(Self { a, b, c })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if self.a > 0x3 {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "a", self.a, 0x3);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "a",
+                value: self.a as u64,
+                maximum_value: 0x3,
+            });
         }
         if self.b > 0xff_ffff {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "b", self.b, 0xff_ffff);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "b",
+                value: self.b as u64,
+                maximum_value: 0xff_ffff,
+            });
         }
         if self.c > 0x3f {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "c", self.c, 0x3f);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "c",
+                value: self.c as u64,
+                maximum_value: 0x3f,
+            });
         }
         let value = (self.a as u32) | (self.b << 2) | ((self.c as u32) << 26);
         buffer.put_u32_le(value);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -82,36 +98,36 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_a(&self) -> u8 {
@@ -123,7 +139,7 @@ impl Foo {
     pub fn get_c(&self) -> u8 {
         self.foo.c
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_mixed_scalars_enums_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_mixed_scalars_enums_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -28,7 +28,7 @@ pub enum Enum7 {
 }
 impl TryFrom<u8> for Enum7 {
     type Error = u8;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x1 => Ok(Enum7::A),
             0x2 => Ok(Enum7::B),
@@ -94,7 +94,7 @@ pub enum Enum9 {
 }
 impl TryFrom<u16> for Enum9 {
     type Error = u16;
-    fn try_from(value: u16) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
         match value {
             0x1 => Ok(Enum9::A),
             0x2 => Ok(Enum9::B),
@@ -166,48 +166,59 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 3
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 3 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 3,
                 got: bytes.get().remaining(),
             });
         }
         let chunk = bytes.get_mut().get_uint(3) as u32;
         let x = Enum7::try_from((chunk & 0x7f) as u8)
-            .map_err(|unknown_val| Error::InvalidEnumValueError {
-                obj: "Foo".to_string(),
-                field: "x".to_string(),
+            .map_err(|unknown_val| DecodeError::InvalidEnumValueError {
+                obj: "Foo",
+                field: "x",
                 value: unknown_val as u64,
-                type_: "Enum7".to_string(),
+                type_: "Enum7",
             })?;
         let y = ((chunk >> 7) & 0x1f) as u8;
         let z = Enum9::try_from(((chunk >> 12) & 0x1ff) as u16)
-            .map_err(|unknown_val| Error::InvalidEnumValueError {
-                obj: "Foo".to_string(),
-                field: "z".to_string(),
+            .map_err(|unknown_val| DecodeError::InvalidEnumValueError {
+                obj: "Foo",
+                field: "z",
                 value: unknown_val as u64,
-                type_: "Enum9".to_string(),
+                type_: "Enum9",
             })?;
         let w = ((chunk >> 21) & 0x7) as u8;
         Ok(Self { x, y, z, w })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if self.y > 0x1f {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "y", self.y, 0x1f);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "y",
+                value: self.y as u64,
+                maximum_value: 0x1f,
+            });
         }
         if self.w > 0x7 {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "w", self.w, 0x7);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "w",
+                value: self.w as u64,
+                maximum_value: 0x7,
+            });
         }
         let value = (u8::from(self.x) as u32) | ((self.y as u32) << 7)
             | ((u16::from(self.z) as u32) << 12) | ((self.w as u32) << 21);
         buffer.put_uint(value as u64, 3);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -217,36 +228,36 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_w(&self) -> u8 {
@@ -261,7 +272,7 @@ impl Foo {
     pub fn get_z(&self) -> Enum9 {
         self.foo.z
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_mixed_scalars_enums_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_mixed_scalars_enums_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -28,7 +28,7 @@ pub enum Enum7 {
 }
 impl TryFrom<u8> for Enum7 {
     type Error = u8;
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0x1 => Ok(Enum7::A),
             0x2 => Ok(Enum7::B),
@@ -94,7 +94,7 @@ pub enum Enum9 {
 }
 impl TryFrom<u16> for Enum9 {
     type Error = u16;
-    fn try_from(value: u16) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
         match value {
             0x1 => Ok(Enum9::A),
             0x2 => Ok(Enum9::B),
@@ -166,48 +166,59 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 3
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 3 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 3,
                 got: bytes.get().remaining(),
             });
         }
         let chunk = bytes.get_mut().get_uint_le(3) as u32;
         let x = Enum7::try_from((chunk & 0x7f) as u8)
-            .map_err(|unknown_val| Error::InvalidEnumValueError {
-                obj: "Foo".to_string(),
-                field: "x".to_string(),
+            .map_err(|unknown_val| DecodeError::InvalidEnumValueError {
+                obj: "Foo",
+                field: "x",
                 value: unknown_val as u64,
-                type_: "Enum7".to_string(),
+                type_: "Enum7",
             })?;
         let y = ((chunk >> 7) & 0x1f) as u8;
         let z = Enum9::try_from(((chunk >> 12) & 0x1ff) as u16)
-            .map_err(|unknown_val| Error::InvalidEnumValueError {
-                obj: "Foo".to_string(),
-                field: "z".to_string(),
+            .map_err(|unknown_val| DecodeError::InvalidEnumValueError {
+                obj: "Foo",
+                field: "z",
                 value: unknown_val as u64,
-                type_: "Enum9".to_string(),
+                type_: "Enum9",
             })?;
         let w = ((chunk >> 21) & 0x7) as u8;
         Ok(Self { x, y, z, w })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if self.y > 0x1f {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "y", self.y, 0x1f);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "y",
+                value: self.y as u64,
+                maximum_value: 0x1f,
+            });
         }
         if self.w > 0x7 {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "w", self.w, 0x7);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "w",
+                value: self.w as u64,
+                maximum_value: 0x7,
+            });
         }
         let value = (u8::from(self.x) as u32) | ((self.y as u32) << 7)
             | ((u16::from(self.z) as u32) << 12) | ((self.w as u32) << 21);
         buffer.put_uint_le(value as u64, 3);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -217,36 +228,36 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_w(&self) -> u8 {
@@ -261,7 +272,7 @@ impl Foo {
     pub fn get_z(&self) -> Enum9 {
         self.foo.z
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_payload_field_unknown_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_payload_field_unknown_size_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -60,15 +60,15 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 3
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 3 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 3,
                 got: bytes.get().remaining(),
             });
@@ -84,15 +84,21 @@ impl FooData {
         };
         Ok(Self { a, child })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if self.a > 0xff_ffff {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "a", self.a, 0xff_ffff);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "a",
+                value: self.a as u64,
+                maximum_value: 0xff_ffff,
+            });
         }
         buffer.put_uint_le(self.a as u64, 3);
         match &self.child {
             FooDataChild::Payload(payload) => buffer.put_slice(payload),
             FooDataChild::None => {}
         }
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -102,32 +108,32 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
@@ -137,7 +143,7 @@ impl Foo {
             FooDataChild::None => FooChild::None,
         }
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_a(&self) -> u32 {
@@ -149,7 +155,7 @@ impl Foo {
             FooDataChild::None => &[],
         }
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_payload_field_unknown_size_terminal_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_payload_field_unknown_size_terminal_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -60,15 +60,15 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 3
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 3 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 3,
                 got: bytes.get().remaining(),
             });
@@ -76,8 +76,8 @@ impl FooData {
         let payload = &bytes.get()[..bytes.get().len() - 3];
         bytes.get_mut().advance(payload.len());
         if bytes.get().remaining() < 3 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 3,
                 got: bytes.get().remaining(),
             });
@@ -91,15 +91,21 @@ impl FooData {
         };
         Ok(Self { a, child })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         match &self.child {
             FooDataChild::Payload(payload) => buffer.put_slice(payload),
             FooDataChild::None => {}
         }
         if self.a > 0xff_ffff {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "a", self.a, 0xff_ffff);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "a",
+                value: self.a as u64,
+                maximum_value: 0xff_ffff,
+            });
         }
         buffer.put_uint(self.a as u64, 3);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -109,32 +115,32 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
@@ -144,7 +150,7 @@ impl Foo {
             FooDataChild::None => FooChild::None,
         }
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_a(&self) -> u32 {
@@ -156,7 +162,7 @@ impl Foo {
             FooDataChild::None => &[],
         }
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_payload_field_unknown_size_terminal_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_payload_field_unknown_size_terminal_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -60,15 +60,15 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 3
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 3 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 3,
                 got: bytes.get().remaining(),
             });
@@ -76,8 +76,8 @@ impl FooData {
         let payload = &bytes.get()[..bytes.get().len() - 3];
         bytes.get_mut().advance(payload.len());
         if bytes.get().remaining() < 3 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 3,
                 got: bytes.get().remaining(),
             });
@@ -91,15 +91,21 @@ impl FooData {
         };
         Ok(Self { a, child })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         match &self.child {
             FooDataChild::Payload(payload) => buffer.put_slice(payload),
             FooDataChild::None => {}
         }
         if self.a > 0xff_ffff {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "a", self.a, 0xff_ffff);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "a",
+                value: self.a as u64,
+                maximum_value: 0xff_ffff,
+            });
         }
         buffer.put_uint_le(self.a as u64, 3);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -109,32 +115,32 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
@@ -144,7 +150,7 @@ impl Foo {
             FooDataChild::None => FooChild::None,
         }
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_a(&self) -> u32 {
@@ -156,7 +162,7 @@ impl Foo {
             FooDataChild::None => &[],
         }
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_payload_field_variable_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_payload_field_variable_size_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -62,31 +62,31 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 4
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 1 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 1,
                 got: bytes.get().remaining(),
             });
         }
         let a = bytes.get_mut().get_u8();
         if bytes.get().remaining() < 1 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 1,
                 got: bytes.get().remaining(),
             });
         }
         let payload_size = bytes.get_mut().get_u8() as usize;
         if bytes.get().remaining() < payload_size {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: payload_size,
                 got: bytes.get().remaining(),
             });
@@ -94,8 +94,8 @@ impl FooData {
         let payload = &bytes.get()[..payload_size];
         bytes.get_mut().advance(payload_size);
         if bytes.get().remaining() < 2 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 2,
                 got: bytes.get().remaining(),
             });
@@ -109,13 +109,15 @@ impl FooData {
         };
         Ok(Self { a, b, child })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         buffer.put_u8(self.a);
         if self.child.get_total_size() > 0xff {
-            panic!(
-                "Invalid length for {}::{}: {} > {}", "Foo", "_payload_", self.child
-                .get_total_size(), 0xff
-            );
+            return Err(EncodeError::SizeOverflow {
+                packet: "Foo",
+                field: "_payload_",
+                size: self.child.get_total_size(),
+                maximum_size: 0xff,
+            });
         }
         buffer.put_u8(self.child.get_total_size() as u8);
         match &self.child {
@@ -123,6 +125,7 @@ impl FooData {
             FooDataChild::None => {}
         }
         buffer.put_u16(self.b);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -132,32 +135,32 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
@@ -167,7 +170,7 @@ impl Foo {
             FooDataChild::None => FooChild::None,
         }
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_a(&self) -> u8 {
@@ -182,7 +185,7 @@ impl Foo {
             FooDataChild::None => &[],
         }
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_reserved_field_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_reserved_field_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -34,15 +34,15 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 5
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 5 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 5,
                 got: bytes.get().remaining(),
             });
@@ -50,8 +50,9 @@ impl FooData {
         bytes.get_mut().advance(5);
         Ok(Self {})
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         buffer.put_bytes(0, 5);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -61,39 +62,39 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_reserved_field_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_reserved_field_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -34,15 +34,15 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 5
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 5 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 5,
                 got: bytes.get().remaining(),
             });
@@ -50,8 +50,9 @@ impl FooData {
         bytes.get_mut().advance(5);
         Ok(Self {})
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         buffer.put_bytes(0, 5);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -61,39 +62,39 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/packet_decl_simple_scalars_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_simple_scalars_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -42,31 +42,31 @@ impl FooData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 6
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 1 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 1,
                 got: bytes.get().remaining(),
             });
         }
         let x = bytes.get_mut().get_u8();
         if bytes.get().remaining() < 2 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 2,
                 got: bytes.get().remaining(),
             });
         }
         let y = bytes.get_mut().get_u16();
         if bytes.get().remaining() < 3 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 3,
                 got: bytes.get().remaining(),
             });
@@ -74,13 +74,19 @@ impl FooData {
         let z = bytes.get_mut().get_uint(3) as u32;
         Ok(Self { x, y, z })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         buffer.put_u8(self.x);
         buffer.put_u16(self.y);
         if self.z > 0xff_ffff {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "z", self.z, 0xff_ffff);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "z",
+                value: self.z as u64,
+                maximum_value: 0xff_ffff,
+            });
         }
         buffer.put_uint(self.z as u64, 3);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -90,36 +96,36 @@ impl FooData {
     }
 }
 impl Packet for Foo {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.foo.get_size());
-        self.foo.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.foo.write_to(buf)
     }
 }
-impl From<Foo> for Bytes {
-    fn from(packet: Foo) -> Self {
-        packet.to_bytes()
+impl TryFrom<Foo> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Foo> for Vec<u8> {
-    fn from(packet: Foo) -> Self {
-        packet.to_vec()
+impl TryFrom<Foo> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Foo) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Foo {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = FooData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(foo: FooData) -> Result<Self> {
+    fn new(foo: FooData) -> Result<Self, DecodeError> {
         Ok(Self { foo })
     }
     pub fn get_x(&self) -> u8 {
@@ -131,7 +137,7 @@ impl Foo {
     pub fn get_z(&self) -> u32 {
         self.foo.z
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.foo.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/preamble.rs
+++ b/pdl-compiler/tests/generated/preamble.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend

--- a/pdl-compiler/tests/generated/reserved_identifier_big_endian.rs
+++ b/pdl-compiler/tests/generated/reserved_identifier_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -38,15 +38,15 @@ impl TestData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 1
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 1 {
-            return Err(Error::InvalidLengthError {
-                obj: "Test".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Test",
                 wanted: 1,
                 got: bytes.get().remaining(),
             });
@@ -54,8 +54,9 @@ impl TestData {
         let r#type = bytes.get_mut().get_u8();
         Ok(Self { r#type })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         buffer.put_u8(self.r#type);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -65,42 +66,42 @@ impl TestData {
     }
 }
 impl Packet for Test {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.test.get_size());
-        self.test.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.test.write_to(buf)
     }
 }
-impl From<Test> for Bytes {
-    fn from(packet: Test) -> Self {
-        packet.to_bytes()
+impl TryFrom<Test> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Test) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Test> for Vec<u8> {
-    fn from(packet: Test) -> Self {
-        packet.to_vec()
+impl TryFrom<Test> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Test) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Test {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = TestData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(test: TestData) -> Result<Self> {
+    fn new(test: TestData) -> Result<Self, DecodeError> {
         Ok(Self { test })
     }
     pub fn get_type(&self) -> u8 {
         self.test.r#type
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.test.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/reserved_identifier_little_endian.rs
+++ b/pdl-compiler/tests/generated/reserved_identifier_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -38,15 +38,15 @@ impl TestData {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 1
     }
-    fn parse(bytes: &[u8]) -> Result<Self> {
+    fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 1 {
-            return Err(Error::InvalidLengthError {
-                obj: "Test".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Test",
                 wanted: 1,
                 got: bytes.get().remaining(),
             });
@@ -54,8 +54,9 @@ impl TestData {
         let r#type = bytes.get_mut().get_u8();
         Ok(Self { r#type })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         buffer.put_u8(self.r#type);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()
@@ -65,42 +66,42 @@ impl TestData {
     }
 }
 impl Packet for Test {
-    fn to_bytes(self) -> Bytes {
-        let mut buffer = BytesMut::with_capacity(self.test.get_size());
-        self.test.write_to(&mut buffer);
-        buffer.freeze()
+    fn encoded_len(&self) -> usize {
+        self.get_size()
     }
-    fn to_vec(self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        self.test.write_to(buf)
     }
 }
-impl From<Test> for Bytes {
-    fn from(packet: Test) -> Self {
-        packet.to_bytes()
+impl TryFrom<Test> for Bytes {
+    type Error = EncodeError;
+    fn try_from(packet: Test) -> Result<Self, Self::Error> {
+        packet.encode_to_bytes()
     }
 }
-impl From<Test> for Vec<u8> {
-    fn from(packet: Test) -> Self {
-        packet.to_vec()
+impl TryFrom<Test> for Vec<u8> {
+    type Error = EncodeError;
+    fn try_from(packet: Test) -> Result<Self, Self::Error> {
+        packet.encode_to_vec()
     }
 }
 impl Test {
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         let data = TestData::parse_inner(&mut bytes)?;
         Self::new(data)
     }
-    fn new(test: TestData) -> Result<Self> {
+    fn new(test: TestData) -> Result<Self, DecodeError> {
         Ok(Self { test })
     }
     pub fn get_type(&self) -> u8 {
         self.test.r#type
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to(&self, buffer: &mut impl BufMut) -> Result<(), EncodeError> {
         self.test.write_to(buffer)
     }
     pub fn get_size(&self) -> usize {

--- a/pdl-compiler/tests/generated/struct_decl_complex_scalars_big_endian.rs
+++ b/pdl-compiler/tests/generated/struct_decl_complex_scalars_big_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -32,15 +32,15 @@ impl Foo {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 7
     }
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 2 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 2,
                 got: bytes.get().remaining(),
             });
@@ -50,16 +50,16 @@ impl Foo {
         let b = (chunk >> 3) as u8;
         let c = ((chunk >> 11) & 0x1f) as u8;
         if bytes.get().remaining() < 3 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 3,
                 got: bytes.get().remaining(),
             });
         }
         let d = bytes.get_mut().get_uint(3) as u32;
         if bytes.get().remaining() < 2 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 2,
                 got: bytes.get().remaining(),
             });
@@ -69,27 +69,53 @@ impl Foo {
         let f = ((chunk >> 12) & 0xf) as u8;
         Ok(Self { a, b, c, d, e, f })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if self.a > 0x7 {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "a", self.a, 0x7);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "a",
+                value: self.a as u64,
+                maximum_value: 0x7,
+            });
         }
         if self.c > 0x1f {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "c", self.c, 0x1f);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "c",
+                value: self.c as u64,
+                maximum_value: 0x1f,
+            });
         }
         let value = (self.a as u16) | ((self.b as u16) << 3) | ((self.c as u16) << 11);
         buffer.put_u16(value);
         if self.d > 0xff_ffff {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "d", self.d, 0xff_ffff);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "d",
+                value: self.d as u64,
+                maximum_value: 0xff_ffff,
+            });
         }
         buffer.put_uint(self.d as u64, 3);
         if self.e > 0xfff {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "e", self.e, 0xfff);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "e",
+                value: self.e as u64,
+                maximum_value: 0xfff,
+            });
         }
         if self.f > 0xf {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "f", self.f, 0xf);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "f",
+                value: self.f as u64,
+                maximum_value: 0xf,
+            });
         }
         let value = self.e | ((self.f as u16) << 12);
         buffer.put_u16(value);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()

--- a/pdl-compiler/tests/generated/struct_decl_complex_scalars_little_endian.rs
+++ b/pdl-compiler/tests/generated/struct_decl_complex_scalars_little_endian.rs
@@ -4,8 +4,8 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::cell::Cell;
 use std::fmt;
-use pdl_runtime::{Error, Packet};
-type Result<T> = std::result::Result<T, Error>;
+use std::result::Result;
+use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// Private prevents users from creating arbitrary scalar values
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
@@ -32,15 +32,15 @@ impl Foo {
     fn conforms(bytes: &[u8]) -> bool {
         bytes.len() >= 7
     }
-    pub fn parse(bytes: &[u8]) -> Result<Self> {
+    pub fn parse(bytes: &[u8]) -> Result<Self, DecodeError> {
         let mut cell = Cell::new(bytes);
         let packet = Self::parse_inner(&mut cell)?;
         Ok(packet)
     }
-    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self> {
+    fn parse_inner(mut bytes: &mut Cell<&[u8]>) -> Result<Self, DecodeError> {
         if bytes.get().remaining() < 2 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 2,
                 got: bytes.get().remaining(),
             });
@@ -50,16 +50,16 @@ impl Foo {
         let b = (chunk >> 3) as u8;
         let c = ((chunk >> 11) & 0x1f) as u8;
         if bytes.get().remaining() < 3 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 3,
                 got: bytes.get().remaining(),
             });
         }
         let d = bytes.get_mut().get_uint_le(3) as u32;
         if bytes.get().remaining() < 2 {
-            return Err(Error::InvalidLengthError {
-                obj: "Foo".to_string(),
+            return Err(DecodeError::InvalidLengthError {
+                obj: "Foo",
                 wanted: 2,
                 got: bytes.get().remaining(),
             });
@@ -69,27 +69,53 @@ impl Foo {
         let f = ((chunk >> 12) & 0xf) as u8;
         Ok(Self { a, b, c, d, e, f })
     }
-    fn write_to(&self, buffer: &mut BytesMut) {
+    fn write_to<T: BufMut>(&self, buffer: &mut T) -> Result<(), EncodeError> {
         if self.a > 0x7 {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "a", self.a, 0x7);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "a",
+                value: self.a as u64,
+                maximum_value: 0x7,
+            });
         }
         if self.c > 0x1f {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "c", self.c, 0x1f);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "c",
+                value: self.c as u64,
+                maximum_value: 0x1f,
+            });
         }
         let value = (self.a as u16) | ((self.b as u16) << 3) | ((self.c as u16) << 11);
         buffer.put_u16_le(value);
         if self.d > 0xff_ffff {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "d", self.d, 0xff_ffff);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "d",
+                value: self.d as u64,
+                maximum_value: 0xff_ffff,
+            });
         }
         buffer.put_uint_le(self.d as u64, 3);
         if self.e > 0xfff {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "e", self.e, 0xfff);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "e",
+                value: self.e as u64,
+                maximum_value: 0xfff,
+            });
         }
         if self.f > 0xf {
-            panic!("Invalid value for {}::{}: {} > {}", "Foo", "f", self.f, 0xf);
+            return Err(EncodeError::InvalidScalarValue {
+                packet: "Foo",
+                field: "f",
+                value: self.f as u64,
+                maximum_value: 0xf,
+            });
         }
         let value = self.e | ((self.f as u16) << 12);
         buffer.put_u16_le(value);
+        Ok(())
     }
     fn get_total_size(&self) -> usize {
         self.get_size()

--- a/pdl-derive/tests/examples.rs
+++ b/pdl-derive/tests/examples.rs
@@ -42,7 +42,8 @@ fn test_pcap() {
     }
     .build();
 
-    assert!(PcapFile::parse(&pcap_file.to_vec()).is_ok());
+    let vec = pcap_file.encode_to_vec().unwrap();
+    assert!(PcapFile::parse(&*vec).is_ok());
 }
 
 #[test]

--- a/pdl-runtime/src/lib.rs
+++ b/pdl-runtime/src/lib.rs
@@ -14,32 +14,65 @@
 
 //! Helper definitions used used by the generated Rust backend.
 
-use bytes::Bytes;
-use thiserror::Error;
+use bytes::{BufMut, Bytes, BytesMut};
 
 /// Type of parsing errors.
-#[derive(Debug, Error, PartialEq, Eq)]
-pub enum Error {
-    #[error("Packet parsing failed")]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum DecodeError {
+    #[error("packet parsing failed")]
     InvalidPacketError,
     #[error("{field} was {value:x}, which is not known")]
-    ConstraintOutOfBounds { field: String, value: u64 },
+    ConstraintOutOfBounds { field: &'static str, value: u64 },
     #[error("Got {actual:x}, expected {expected:x}")]
     InvalidFixedValue { expected: u64, actual: u64 },
     #[error("when parsing {obj} needed length of {wanted} but got {got}")]
-    InvalidLengthError { obj: String, wanted: usize, got: usize },
+    InvalidLengthError { obj: &'static str, wanted: usize, got: usize },
     #[error("array size ({array} bytes) is not a multiple of the element size ({element} bytes)")]
     InvalidArraySize { array: usize, element: usize },
     #[error("Due to size restrictions a struct could not be parsed.")]
     ImpossibleStructError,
     #[error("when parsing field {obj}.{field}, {value} is not a valid {type_} value")]
-    InvalidEnumValueError { obj: String, field: String, value: u64, type_: String },
+    InvalidEnumValueError { obj: &'static str, field: &'static str, value: u64, type_: &'static str },
     #[error("expected child {expected}, got {actual}")]
     InvalidChildError { expected: &'static str, actual: String },
+    #[error("packet has trailing bytes")]
+    TrailingBytes,
+}
+
+/// Type of serialization errors.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum EncodeError {
+    #[error("the size of {packet}::{field} ({size}) is outside the range of valid values 0..{maximum_size}")]
+    SizeOverflow { packet: &'static str, field: &'static str, size: usize, maximum_size: usize },
+    #[error(
+        "the count of {packet}::{field} ({count}) is outside the range of valid values 0..{maximum_count}"
+    )]
+    CountOverflow { packet: &'static str, field: &'static str, count: usize, maximum_count: usize },
+    #[error(
+        "the value of {packet}::{field} ({value}) is outside the range of valid values 0..{maximum_value}"
+    )]
+    InvalidScalarValue { packet: &'static str, field: &'static str, value: u64, maximum_value: u64 },
 }
 
 /// Trait implemented for all toplevel packet declarations.
-pub trait Packet {
-    fn to_bytes(self) -> Bytes;
-    fn to_vec(self) -> Vec<u8>;
+pub trait Packet: Sized {
+    /// Return the length of the encoded packet.
+    fn encoded_len(&self) -> usize;
+
+    /// Write the packet to an output buffer.
+    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError>;
+
+    /// Encode the packet to a byte vector.
+    fn encode_to_vec(&self) -> Result<Vec<u8>, EncodeError> {
+        let mut buf = Vec::with_capacity(self.encoded_len());
+        self.encode(&mut buf)?;
+        Ok(buf)
+    }
+
+    /// Encode the packet to a Bytes object.
+    fn encode_to_bytes(&self) -> Result<Bytes, EncodeError> {
+        let mut buf = BytesMut::with_capacity(self.encoded_len());
+        self.encode(&mut buf)?;
+        Ok(buf.freeze())
+    }
 }


### PR DESCRIPTION
Fixes #74

- add encode<T: BufMut>(&self, buf: &mut T)
  which encodes the packet or struct to an existing
  buffer (#74). encode is faillible, and is expected
  to return an error if an inconsistency is found
  (e.g. size or padding overflow)
- derive the implementation for encode_to_vec and
  encode_to_bytes from encode
- separate encoding and decoding error types
- remove panics related to packet encoding (#22)
