### PR TITLE
Provide manual implementation of Debug for Private<T>

### DIFF
--- a/pdl-compiler/src/backends/rust/preamble.rs
+++ b/pdl-compiler/src/backends/rust/preamble.rs
@@ -62,13 +62,19 @@ pub fn generate(path: &Path) -> proc_macro2::TokenStream {
         /// in situations where the value needs to be validated.
         /// Users can freely deref the value, but only the backend
         /// may create it.
-        #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+        #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
         pub struct Private<T>(T);
 
         impl<T> std::ops::Deref for Private<T> {
             type Target = T;
             fn deref(&self) -> &Self::Target {
                 &self.0
+            }
+        }
+
+        impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                T::fmt(&self.0, f)
             }
         }
     }

--- a/pdl-compiler/tests/generated/custom_field_declaration_big_endian.rs
+++ b/pdl-compiler/tests/generated/custom_field_declaration_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]

--- a/pdl-compiler/tests/generated/custom_field_declaration_little_endian.rs
+++ b/pdl-compiler/tests/generated/custom_field_declaration_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]

--- a/pdl-compiler/tests/generated/enum_declaration_big_endian.rs
+++ b/pdl-compiler/tests/generated/enum_declaration_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/enum_declaration_little_endian.rs
+++ b/pdl-compiler/tests/generated/enum_declaration_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_24bit_enum_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_24bit_enum_array_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_24bit_enum_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_24bit_enum_array_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_24bit_enum_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_24bit_enum_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_24bit_enum_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_24bit_enum_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_24bit_scalar_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_24bit_scalar_array_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_24bit_scalar_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_24bit_scalar_array_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_24bit_scalar_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_24bit_scalar_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_24bit_scalar_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_24bit_scalar_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_64bit_enum_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_enum_array_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_64bit_enum_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_enum_array_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_64bit_enum_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_enum_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_64bit_enum_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_enum_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_64bit_scalar_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_scalar_array_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_64bit_scalar_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_scalar_array_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_64bit_scalar_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_scalar_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_64bit_scalar_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_64bit_scalar_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_8bit_enum_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_enum_array_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_8bit_enum_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_enum_array_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_8bit_enum_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_enum_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_8bit_enum_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_enum_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_8bit_scalar_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_scalar_array_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_8bit_scalar_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_scalar_array_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_8bit_scalar_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_scalar_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_8bit_scalar_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_8bit_scalar_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_array_dynamic_count_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_dynamic_count_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_array_dynamic_count_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_dynamic_count_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_array_dynamic_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_dynamic_size_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_array_dynamic_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_dynamic_size_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_count_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_count_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_count_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_count_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_size_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_unknown_element_width_dynamic_size_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_array_with_padding_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_with_padding_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_array_with_padding_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_array_with_padding_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_child_packets_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_child_packets_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_child_packets_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_child_packets_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_complex_scalars_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_complex_scalars_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_complex_scalars_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_complex_scalars_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_custom_field_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_custom_field_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]

--- a/pdl-compiler/tests/generated/packet_decl_custom_field_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_custom_field_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]

--- a/pdl-compiler/tests/generated/packet_decl_empty_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_empty_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_empty_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_empty_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_fixed_enum_field_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_fixed_enum_field_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_fixed_enum_field_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_fixed_enum_field_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_fixed_scalar_field_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_fixed_scalar_field_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_fixed_scalar_field_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_fixed_scalar_field_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_grand_children_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_grand_children_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_grand_children_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_grand_children_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_mask_scalar_value_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_mask_scalar_value_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_mask_scalar_value_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_mask_scalar_value_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_mixed_scalars_enums_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_mixed_scalars_enums_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_mixed_scalars_enums_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_mixed_scalars_enums_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_parent_with_alias_child_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_parent_with_alias_child_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_parent_with_alias_child_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_parent_with_alias_child_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_parent_with_no_payload_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_parent_with_no_payload_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_parent_with_no_payload_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_parent_with_no_payload_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[repr(u64)]

--- a/pdl-compiler/tests/generated/packet_decl_payload_field_unknown_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_payload_field_unknown_size_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_payload_field_unknown_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_payload_field_unknown_size_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_payload_field_unknown_size_terminal_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_payload_field_unknown_size_terminal_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_payload_field_unknown_size_terminal_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_payload_field_unknown_size_terminal_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_payload_field_variable_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_payload_field_variable_size_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_payload_field_variable_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_payload_field_variable_size_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_reserved_field_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_reserved_field_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_reserved_field_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_reserved_field_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_simple_scalars_big_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_simple_scalars_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/packet_decl_simple_scalars_little_endian.rs
+++ b/pdl-compiler/tests/generated/packet_decl_simple_scalars_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/payload_with_size_modifier_big_endian.rs
+++ b/pdl-compiler/tests/generated/payload_with_size_modifier_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/payload_with_size_modifier_little_endian.rs
+++ b/pdl-compiler/tests/generated/payload_with_size_modifier_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/preamble.rs
+++ b/pdl-compiler/tests/generated/preamble.rs
@@ -10,11 +10,16 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }

--- a/pdl-compiler/tests/generated/reserved_identifier_big_endian.rs
+++ b/pdl-compiler/tests/generated/reserved_identifier_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/reserved_identifier_little_endian.rs
+++ b/pdl-compiler/tests/generated/reserved_identifier_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/struct_decl_complex_scalars_big_endian.rs
+++ b/pdl-compiler/tests/generated/struct_decl_complex_scalars_big_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/pdl-compiler/tests/generated/struct_decl_complex_scalars_little_endian.rs
+++ b/pdl-compiler/tests/generated/struct_decl_complex_scalars_little_endian.rs
@@ -10,12 +10,17 @@ use pdl_runtime::{DecodeError, EncodeError, Packet};
 /// in situations where the value needs to be validated.
 /// Users can freely deref the value, but only the backend
 /// may create it.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Private<T>(T);
 impl<T> std::ops::Deref for Private<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::fmt(&self.0, f)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
format!("{:?}", Private(42)) will print "42" instead
of "Private(42)"
