### PR TITLE
Fix unnecessary-get-then-check clippy warning

### DIFF
--- a/pdl-compiler/src/backends/rust/mod.rs
+++ b/pdl-compiler/src/backends/rust/mod.rs
@@ -90,7 +90,7 @@ fn packet_data_fields<'a>(
         .iter_fields(decl)
         .filter(|f| f.id().is_some())
         .filter(|f| !matches!(&f.desc, ast::FieldDesc::Flag { .. }))
-        .filter(|f| all_constraints.get(f.id().unwrap()).is_none())
+        .filter(|f| !all_constraints.contains_key(f.id().unwrap()))
         .collect::<Vec<_>>()
 }
 
@@ -108,7 +108,7 @@ fn packet_constant_fields<'a>(
     scope
         .iter_fields(decl)
         .filter(|f| f.id().is_some())
-        .filter(|f| all_constraints.get(f.id().unwrap()).is_some())
+        .filter(|f| all_constraints.contains_key(f.id().unwrap()))
         .collect::<Vec<_>>()
 }
 


### PR DESCRIPTION
error: unnecessary use of `get(f.id().unwrap()).is_none()`
  --> pdl-compiler/src/backends/rust/mod.rs:93:37
   |
93 |         .filter(|f| all_constraints.get(f.id().unwrap()).is_none())
   |                     ----------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |                     |
   |                     help: replace it with: `!all_constraints.contains_key(f.id().unwrap())`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_get_then_check
   = note: `-D clippy::unnecessary-get-then-check` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::unnecessary_get_then_check)]`

error: unnecessary use of `get(f.id().unwrap()).is_some()`
   --> pdl-compiler/src/backends/rust/mod.rs:111:37
    |
111 |         .filter(|f| all_constraints.get(f.id().unwrap()).is_some())
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `contains_key(f.id().unwrap())`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_get_then_check