### PR TITLE
Allow derived structs in packets in new rust generator

### DIFF
--- a/pdl-compiler/src/backends/rust/parser.rs
+++ b/pdl-compiler/src/backends/rust/parser.rs
@@ -524,10 +524,6 @@ impl<'a> FieldParser<'a> {
         assert_eq!(self.shift, 0, "Typedef field does not start on an octet boundary");
 
         let decl = self.scope.typedef[type_id];
-        if let ast::DeclDesc::Struct { parent_id: Some(_), .. } = &decl.desc {
-            panic!("Derived struct used in typedef field");
-        }
-
         let span = self.span;
         let id = id.to_ident();
         let type_id = type_id.to_ident();
@@ -555,11 +551,8 @@ impl<'a> FieldParser<'a> {
                         }
                     }
                     ast::DeclDesc::Struct { .. } => {
-                        let width = syn::Index::from(width / 8);
                         quote! {
-                            let (head, tail) = #span.split_at(#width);
-                            #span = tail;
-                            let #id = #type_id::decode_full(head)?;
+                            let (#id, mut #span) = #type_id::decode(#span)?;
                         }
                     }
                     _ => unreachable!(),

--- a/pdl-compiler/src/backends/rust/serializer.rs
+++ b/pdl-compiler/src/backends/rust/serializer.rs
@@ -115,10 +115,6 @@ impl Encoder {
         assert_eq!(self.bit_shift, 0, "Typedef field does not start on an octet boundary");
 
         let decl = scope.typedef[type_id];
-        if let ast::DeclDesc::Struct { parent_id: Some(_), .. } = &decl.desc {
-            panic!("Derived struct used in typedef field");
-        }
-
         let id = id.to_ident();
         let buf = &self.buf;
 


### PR DESCRIPTION
The legacy rust generator did not support derived structs because of
lack of common interface for parsing packets.
All packets under the new generator implement Packet::decode which
make it trivial to support.