### PR TITLE
Fix python generation error for dynamic-element size arrays

### DIFF
--- a/pdl-compiler/scripts/generate_python_backend.py
+++ b/pdl-compiler/scripts/generate_python_backend.py
@@ -935,7 +935,10 @@ def generate_packet_parser(packet: ast.Declaration) -> List[str]:
         # is given for specialization.
         for _, child in children:
             specialization.append("try:")
-            specialization.append(f"    return {child.id}.parse(fields.copy(), payload)")
+            specialization.append(f"    child, remainder = {child.id}.parse(fields.copy(), payload)")
+            specialization.append("    if remainder:")
+            specialization.append("        raise Exception('Unexpected parsing remainder')")
+            specialization.append("    return child, span")
             specialization.append("except Exception as exn:")
             specialization.append("    pass")
 

--- a/pdl-compiler/src/backends/rust/mod.rs
+++ b/pdl-compiler/src/backends/rust/mod.rs
@@ -72,9 +72,11 @@ pub fn mask_bits(n: usize, suffix: &str) -> syn::LitInt {
 
 /// Return the list of fields that will appear in the generated
 /// rust structs (<Packet> and <Packet>Builder).
+///
 ///  - must be a named field
 ///  - must not be a flag
 ///  - must not appear in the packet constraints.
+///
 /// The fields are presented in declaration order, with ancestor
 /// fields declared first.
 /// The payload field _ if declared _ is handled separately.

--- a/pdl-derive/tests/examples.rs
+++ b/pdl-derive/tests/examples.rs
@@ -46,7 +46,6 @@ fn test_pcap() {
 }
 
 #[test]
-#[cfg(disabled)]
 fn test_jpeg() {
     // The JPEG syntax depends on struct inheritance which is currently
     // not supported. https://github.com/google/pdl/issues/62


### PR DESCRIPTION
The generated code for the following was incorrect and stopped
parsing at the first element:

```
struct Inner {
  _size_(value): 8,
  value: 8[],
}

struct Outer {
  elements: Inner[],
}
```
