### PR TITLE
optional: allow duplicate if statements

### DIFF
--- a/pdl-compiler/src/ast.rs
+++ b/pdl-compiler/src/ast.rs
@@ -144,7 +144,7 @@ pub enum FieldDesc {
     /// Special case of Scalar for fields used as condition for
     /// optional fields. The width is always 1.
     #[serde(rename = "flag_field")]
-    Flag { id: String, optional_field_id: String, set_value: usize },
+    Flag { id: String, optional_field_ids: Vec<(String, usize)> },
     #[serde(rename = "typedef_field")]
     Typedef { id: String, type_id: String },
     #[serde(rename = "group_field")]

--- a/pdl-compiler/src/backends/rust_legacy/serializer.rs
+++ b/pdl-compiler/src/backends/rust_legacy/serializer.rs
@@ -143,7 +143,10 @@ impl<'a> FieldSerializer<'a> {
         let shift = self.shift;
 
         match &field.desc {
-            ast::FieldDesc::Flag { optional_field_id, set_value, .. } => {
+            ast::FieldDesc::Flag { optional_field_ids, .. } => {
+                assert!(optional_field_ids.len() == 1, "condition flag reuse not supported by legacy generator");
+
+                let (optional_field_id, set_value) = &optional_field_ids[0];
                 let optional_field_id = optional_field_id.to_ident();
                 let cond_value_present =
                     syn::parse_str::<syn::LitInt>(&format!("{}", set_value)).unwrap();

--- a/pdl-runtime/src/lib.rs
+++ b/pdl-runtime/src/lib.rs
@@ -76,6 +76,8 @@ pub enum EncodeError {
         expected_size: usize,
         element_index: usize,
     },
+    #[error("{packet}.{field} value cannot be uniquely determined")]
+    InconsistentConditionValue { packet: &'static str, field: &'static str},
 }
 
 /// Trait implemented for all toplevel packet declarations.

--- a/pdl-tests/tests/semantic.rs
+++ b/pdl-tests/tests/semantic.rs
@@ -1,0 +1,80 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use pdl_derive::pdl_inline;
+
+#[pdl_inline(
+    r#"
+little_endian_packets
+
+enum Enum16 : 16 {
+   X = 0x1234,
+   Y = 0x5678,
+}
+
+packet CondTest {
+  cond: 1,
+  _reserved_ : 7,
+  a: 8 if cond = 0,
+  b: Enum16 if cond = 1,
+}
+"#
+)]
+#[cfg(test)]
+mod optional_field {
+    #[test]
+    fn test_value_0() {
+      // Success
+      let test_value_0 = CondTest {
+        a: Some(255),
+        b: None,
+      };
+      let mut buf = vec![];
+      assert!(test_value_0.encode(&mut buf).is_ok());
+
+      let decoded_cond = CondTest::decode_full(&buf).unwrap();
+      assert_eq!(decoded_cond.a, test_value_0.a);
+      assert_eq!(decoded_cond.b, test_value_0.b);
+    }
+
+    #[test]
+    fn test_value_1() {
+      // Success
+      let test_value_1 = CondTest {
+        a: None,
+        b: Some(Enum16::X),
+      };
+      let mut buf = vec![];
+      assert!(test_value_1.encode(&mut buf).is_ok());
+
+      let decoded_cond = CondTest::decode_full(&buf).unwrap();
+      assert_eq!(decoded_cond.a, test_value_1.a);
+      assert_eq!(decoded_cond.b, test_value_1.b);
+    }
+
+    #[test]
+    fn test_value_inconsistent() {
+      let test_value_none = CondTest {
+        a: None,
+        b: None,
+      };
+      assert!(matches!(test_value_none.encode_to_vec(), Err(EncodeError::InconsistentConditionValue { .. })));
+
+      let test_value_both = CondTest {
+        a: Some(255),
+        b: Some(Enum16::X),
+      };
+      assert!(matches!(test_value_both.encode_to_vec(), Err(EncodeError::InconsistentConditionValue { .. })));
+    }
+}


### PR DESCRIPTION
I've got the following usecase requiring me to use `if` twice
```
     tx_timestamp_length : 1,
     tx_timestamp_40: 40 if tx_timestamp_length = 0,
     tx_timestamp_64: 64 if tx_timestamp_length = 1,
```

Right now `check_optional_fields` disallows this while it's working perfectly fine.
This PR removes the check and allows the use of an `if` condition.