### PR TITLE
Update crate dependency version to match AOSP crates

### DIFF
--- a/pdl-compiler/Cargo.toml
+++ b/pdl-compiler/Cargo.toml
@@ -25,15 +25,15 @@ default = ["serde"]
 
 [dependencies]
 codespan-reporting = "0.11.1"
-heck = "0.4.0"
+heck = "0.4.1"
 pest = "2.7.6"
 pest_derive = "2.7.6"
-proc-macro2 = "1.0.46"
-quote = "1.0.21"
-serde_json = "1.0.86"
-argh = "0.1.7"
-syn = "2.0.16"
-prettyplease = "0.2.6"
+proc-macro2 = "1.0.75"
+quote = "1.0.36"
+serde_json = "1.0.94"
+argh = "0.1.12"
+syn = "2.0.58"
+prettyplease = "0.2.17"
 
 [dependencies.serde]
 version = "1.0.145"

--- a/pdl-runtime/Cargo.toml
+++ b/pdl-runtime/Cargo.toml
@@ -15,5 +15,5 @@ authors = [
 categories = ["parsing"]
 
 [dependencies]
-bytes = "1.4.0"
-thiserror = "1.0.47"
+bytes = "1.7.2"
+thiserror = "1.0.49"


### PR DESCRIPTION
For pdl-compiler:

heck 0.4.0 -> 0.4.1
proc-macro2 1.0.46 -> 1.0.75
quote 1.0.21 -> 1.0.36
serde_json 1.0.86 -> 1.0.94
argh 0.1.7 -> 0.1.12
syn 2.0.16 -> 2.0.58
prettyplease 0.2.6 -> 0.2.17

For pdl-runtime
bytes 1.4.0 -> 1.7.2
thiserror 1.0.47 -> 1.0.49
