### PR TITLE
add Default trait to generated types

### DIFF
--- a/pdl-compiler/src/backends/rust/mod.rs
+++ b/pdl-compiler/src/backends/rust/mod.rs
@@ -509,10 +509,11 @@ fn generate_root_packet_decl(
     let child_struct = (!children_decl.is_empty()).then(|| {
         let children_ids = children_decl.iter().map(|decl| decl.id().unwrap().to_ident());
         quote! {
-            #[derive(Debug, Clone, PartialEq, Eq)]
+            #[derive(Default, Debug, Clone, PartialEq, Eq)]
             #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
             pub enum #child_name {
                 #( #children_ids(#children_ids), )*
+                #[default]
                 None,
             }
         }
@@ -525,7 +526,7 @@ fn generate_root_packet_decl(
         .then(|| generate_specialize_impl(scope, schema, decl, id, &data_fields).unwrap());
 
     quote! {
-        #[derive(Debug, Clone, PartialEq, Eq)]
+        #[derive(Default, Debug, Clone, PartialEq, Eq)]
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         pub struct #name {
             #( pub #data_field_ids: #data_field_types, )*
@@ -849,10 +850,11 @@ fn generate_derived_packet_decl(
     let child_struct = (!children_decl.is_empty()).then(|| {
         let children_ids = children_decl.iter().map(|decl| decl.id().unwrap().to_ident());
         quote! {
-            #[derive(Debug, Clone, PartialEq, Eq)]
+            #[derive(Default, Debug, Clone, PartialEq, Eq)]
             #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
             pub enum #child_name {
                 #( #children_ids(#children_ids), )*
+                #[default]
                 None,
             }
         }
@@ -865,7 +867,7 @@ fn generate_derived_packet_decl(
         .then(|| generate_specialize_impl(scope, schema, decl, id, &data_fields).unwrap());
 
     quote! {
-        #[derive(Debug, Clone, PartialEq, Eq)]
+        #[derive(Default, Debug, Clone, PartialEq, Eq)]
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         pub struct #name {
             #( pub #data_field_ids: #data_field_types, )*
@@ -1078,10 +1080,12 @@ fn generate_enum_decl(id: &str, tags: &[ast::Tag], width: usize) -> proc_macro2:
 
     quote! {
         #repr_u64
-        #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+        #[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[cfg_attr(feature = "serde", serde(try_from = #backing_type_str, into = #backing_type_str))]
         pub enum #name {
+            // No specific value => use the first one as default
+            #[default]
             #(#variants,)*
         }
 
@@ -1185,7 +1189,7 @@ fn generate_custom_field_decl(
 
     if backing_type.width == width {
         quote! {
-            #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+            #[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
             #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
             #[cfg_attr(feature = "serde", serde(from = #backing_type_str, into = #backing_type_str))]
             pub struct #id(#backing_type);
@@ -1201,7 +1205,7 @@ fn generate_custom_field_decl(
     } else {
         let max_value = mask_bits(width, &format!("u{}", backing_type.width));
         quote! {
-            #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+            #[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
             #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
             #[cfg_attr(feature = "serde", serde(try_from = #backing_type_str, into = #backing_type_str))]
             pub struct #id(#backing_type);

--- a/pdl-compiler/tests/generated/rust/custom_field_declaration_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/custom_field_declaration_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(from = "u32", into = "u32"))]
 pub struct ExactSize(u32);
@@ -61,7 +61,7 @@ impl From<u32> for ExactSize {
         ExactSize(value)
     }
 }
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u32", into = "u32"))]
 pub struct TruncatedSize(u32);

--- a/pdl-compiler/tests/generated/rust/custom_field_declaration_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/custom_field_declaration_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(from = "u32", into = "u32"))]
 pub struct ExactSize(u32);
@@ -61,7 +61,7 @@ impl From<u32> for ExactSize {
         ExactSize(value)
     }
 }
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u32", into = "u32"))]
 pub struct TruncatedSize(u32);

--- a/pdl-compiler/tests/generated/rust/enum_declaration_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/enum_declaration_big_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum IncompleteTruncatedClosed {
+    #[default]
     A = 0x0,
     B = 0x1,
 }
@@ -89,10 +90,11 @@ impl From<IncompleteTruncatedClosed> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum IncompleteTruncatedOpen {
+    #[default]
     A,
     B,
     Unknown(Private<u8>),
@@ -157,10 +159,11 @@ impl From<IncompleteTruncatedOpen> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum IncompleteTruncatedClosedWithRange {
+    #[default]
     A,
     X,
     Y,
@@ -228,10 +231,11 @@ impl From<IncompleteTruncatedClosedWithRange> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum IncompleteTruncatedOpenWithRange {
+    #[default]
     A,
     X,
     Y,
@@ -303,10 +307,11 @@ impl From<IncompleteTruncatedOpenWithRange> for u64 {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum CompleteTruncated {
+    #[default]
     A = 0x0,
     B = 0x1,
     C = 0x2,
@@ -386,10 +391,11 @@ impl From<CompleteTruncated> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum CompleteTruncatedWithRange {
+    #[default]
     A,
     X,
     Y,
@@ -457,10 +463,11 @@ impl From<CompleteTruncatedWithRange> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum CompleteWithRange {
+    #[default]
     A,
     B,
     C(Private<u8>),

--- a/pdl-compiler/tests/generated/rust/enum_declaration_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/enum_declaration_little_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum IncompleteTruncatedClosed {
+    #[default]
     A = 0x0,
     B = 0x1,
 }
@@ -89,10 +90,11 @@ impl From<IncompleteTruncatedClosed> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum IncompleteTruncatedOpen {
+    #[default]
     A,
     B,
     Unknown(Private<u8>),
@@ -157,10 +159,11 @@ impl From<IncompleteTruncatedOpen> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum IncompleteTruncatedClosedWithRange {
+    #[default]
     A,
     X,
     Y,
@@ -228,10 +231,11 @@ impl From<IncompleteTruncatedClosedWithRange> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum IncompleteTruncatedOpenWithRange {
+    #[default]
     A,
     X,
     Y,
@@ -303,10 +307,11 @@ impl From<IncompleteTruncatedOpenWithRange> for u64 {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum CompleteTruncated {
+    #[default]
     A = 0x0,
     B = 0x1,
     C = 0x2,
@@ -386,10 +391,11 @@ impl From<CompleteTruncated> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum CompleteTruncatedWithRange {
+    #[default]
     A,
     X,
     Y,
@@ -457,10 +463,11 @@ impl From<CompleteTruncatedWithRange> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum CompleteWithRange {
+    #[default]
     A,
     B,
     C(Private<u8>),

--- a/pdl-compiler/tests/generated/rust/packet_decl_24bit_enum_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_24bit_enum_array_big_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u32", into = "u32"))]
 pub enum Foo {
+    #[default]
     FooBar = 0x1,
     Baz = 0x2,
 }
@@ -69,7 +70,7 @@ impl From<Foo> for u64 {
         u32::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: [Foo; 5],

--- a/pdl-compiler/tests/generated/rust/packet_decl_24bit_enum_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_24bit_enum_array_little_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u32", into = "u32"))]
 pub enum Foo {
+    #[default]
     FooBar = 0x1,
     Baz = 0x2,
 }
@@ -69,7 +70,7 @@ impl From<Foo> for u64 {
         u32::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: [Foo; 5],

--- a/pdl-compiler/tests/generated/rust/packet_decl_24bit_enum_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_24bit_enum_big_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u32", into = "u32"))]
 pub enum Foo {
+    #[default]
     A = 0x1,
     B = 0x2,
 }
@@ -69,7 +70,7 @@ impl From<Foo> for u64 {
         u32::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Foo,

--- a/pdl-compiler/tests/generated/rust/packet_decl_24bit_enum_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_24bit_enum_little_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u32", into = "u32"))]
 pub enum Foo {
+    #[default]
     A = 0x1,
     B = 0x2,
 }
@@ -69,7 +70,7 @@ impl From<Foo> for u64 {
         u32::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Foo,

--- a/pdl-compiler/tests/generated/rust/packet_decl_24bit_scalar_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_24bit_scalar_array_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: [u32; 5],

--- a/pdl-compiler/tests/generated/rust/packet_decl_24bit_scalar_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_24bit_scalar_array_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: [u32; 5],

--- a/pdl-compiler/tests/generated/rust/packet_decl_24bit_scalar_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_24bit_scalar_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: u32,

--- a/pdl-compiler/tests/generated/rust/packet_decl_24bit_scalar_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_24bit_scalar_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: u32,

--- a/pdl-compiler/tests/generated/rust/packet_decl_64bit_enum_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_64bit_enum_array_big_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u64", into = "u64"))]
 pub enum Foo {
+    #[default]
     FooBar = 0x1,
     Baz = 0x2,
 }
@@ -54,7 +55,7 @@ impl From<Foo> for u64 {
         (&value).into()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: [Foo; 7],

--- a/pdl-compiler/tests/generated/rust/packet_decl_64bit_enum_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_64bit_enum_array_little_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u64", into = "u64"))]
 pub enum Foo {
+    #[default]
     FooBar = 0x1,
     Baz = 0x2,
 }
@@ -54,7 +55,7 @@ impl From<Foo> for u64 {
         (&value).into()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: [Foo; 7],

--- a/pdl-compiler/tests/generated/rust/packet_decl_64bit_enum_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_64bit_enum_big_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u64", into = "u64"))]
 pub enum Foo {
+    #[default]
     A = 0x1,
     B = 0x2,
 }
@@ -54,7 +55,7 @@ impl From<Foo> for u64 {
         (&value).into()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Foo,

--- a/pdl-compiler/tests/generated/rust/packet_decl_64bit_enum_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_64bit_enum_little_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u64", into = "u64"))]
 pub enum Foo {
+    #[default]
     A = 0x1,
     B = 0x2,
 }
@@ -54,7 +55,7 @@ impl From<Foo> for u64 {
         (&value).into()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Foo,

--- a/pdl-compiler/tests/generated/rust/packet_decl_64bit_scalar_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_64bit_scalar_array_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: [u64; 7],

--- a/pdl-compiler/tests/generated/rust/packet_decl_64bit_scalar_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_64bit_scalar_array_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: [u64; 7],

--- a/pdl-compiler/tests/generated/rust/packet_decl_64bit_scalar_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_64bit_scalar_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: u64,

--- a/pdl-compiler/tests/generated/rust/packet_decl_64bit_scalar_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_64bit_scalar_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: u64,

--- a/pdl-compiler/tests/generated/rust/packet_decl_8bit_enum_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_8bit_enum_array_big_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Foo {
+    #[default]
     FooBar = 0x1,
     Baz = 0x2,
 }
@@ -84,7 +85,7 @@ impl From<Foo> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: [Foo; 3],

--- a/pdl-compiler/tests/generated/rust/packet_decl_8bit_enum_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_8bit_enum_array_little_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Foo {
+    #[default]
     FooBar = 0x1,
     Baz = 0x2,
 }
@@ -84,7 +85,7 @@ impl From<Foo> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: [Foo; 3],

--- a/pdl-compiler/tests/generated/rust/packet_decl_8bit_enum_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_8bit_enum_big_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Foo {
+    #[default]
     A = 0x1,
     B = 0x2,
 }
@@ -84,7 +85,7 @@ impl From<Foo> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Foo,

--- a/pdl-compiler/tests/generated/rust/packet_decl_8bit_enum_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_8bit_enum_little_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Foo {
+    #[default]
     A = 0x1,
     B = 0x2,
 }
@@ -84,7 +85,7 @@ impl From<Foo> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Foo,

--- a/pdl-compiler/tests/generated/rust/packet_decl_8bit_scalar_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_8bit_scalar_array_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: [u8; 3],

--- a/pdl-compiler/tests/generated/rust/packet_decl_8bit_scalar_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_8bit_scalar_array_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: [u8; 3],

--- a/pdl-compiler/tests/generated/rust/packet_decl_8bit_scalar_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_8bit_scalar_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: u8,

--- a/pdl-compiler/tests/generated/rust/packet_decl_8bit_scalar_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_8bit_scalar_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: u8,

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_count_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_count_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub padding: u8,

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_count_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_count_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub padding: u8,

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub inner: Vec<u8>,
@@ -51,7 +51,7 @@ impl Packet for Foo {
         Ok((Self { inner }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub padding: u8,

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_dynamic_count_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_dynamic_count_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub inner: Vec<u8>,
@@ -51,7 +51,7 @@ impl Packet for Foo {
         Ok((Self { inner }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Vec<Foo>,

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_dynamic_count_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_dynamic_count_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub inner: Vec<u8>,
@@ -51,7 +51,7 @@ impl Packet for Foo {
         Ok((Self { inner }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Vec<Foo>,

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_dynamic_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_dynamic_size_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub inner: Vec<u8>,
@@ -51,7 +51,7 @@ impl Packet for Foo {
         Ok((Self { inner }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Vec<Foo>,

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_dynamic_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_dynamic_size_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub inner: Vec<u8>,
@@ -51,7 +51,7 @@ impl Packet for Foo {
         Ok((Self { inner }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Vec<Foo>,

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub inner: Vec<u8>,
@@ -51,7 +51,7 @@ impl Packet for Foo {
         Ok((Self { inner }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub padding: u8,

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_static_count_1_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_static_count_1_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub inner: Vec<u8>,
@@ -51,7 +51,7 @@ impl Packet for Foo {
         Ok((Self { inner }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub padding: u8,

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_static_count_1_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_static_count_1_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub inner: Vec<u8>,
@@ -51,7 +51,7 @@ impl Packet for Foo {
         Ok((Self { inner }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub padding: u8,

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_static_count_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_static_count_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub inner: Vec<u8>,
@@ -51,7 +51,7 @@ impl Packet for Foo {
         Ok((Self { inner }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub padding: u8,

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_static_count_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_static_count_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub inner: Vec<u8>,
@@ -51,7 +51,7 @@ impl Packet for Foo {
         Ok((Self { inner }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub padding: u8,

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_size_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub padding: u8,

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_size_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub padding: u8,

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_unknown_element_width_dynamic_count_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_unknown_element_width_dynamic_count_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: Vec<u16>,
@@ -74,7 +74,7 @@ impl Packet for Foo {
         Ok((Self { a }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Vec<Foo>,

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_unknown_element_width_dynamic_count_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_unknown_element_width_dynamic_count_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: Vec<u16>,
@@ -74,7 +74,7 @@ impl Packet for Foo {
         Ok((Self { a }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Vec<Foo>,

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_unknown_element_width_dynamic_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_unknown_element_width_dynamic_size_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: Vec<u16>,
@@ -74,7 +74,7 @@ impl Packet for Foo {
         Ok((Self { a }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Vec<Foo>,

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_unknown_element_width_dynamic_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_unknown_element_width_dynamic_size_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: Vec<u16>,
@@ -74,7 +74,7 @@ impl Packet for Foo {
         Ok((Self { a }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Vec<Foo>,

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_with_padding_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_with_padding_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: Vec<u16>,
@@ -74,7 +74,7 @@ impl Packet for Foo {
         Ok((Self { a }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub a: Vec<Foo>,

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_with_padding_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_with_padding_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: Vec<u16>,
@@ -74,7 +74,7 @@ impl Packet for Foo {
         Ok((Self { a }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub a: Vec<Foo>,

--- a/pdl-compiler/tests/generated/rust/packet_decl_child_packets_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_child_packets_big_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
 pub enum Enum16 {
+    #[default]
     A = 0x1,
     B = 0x2,
 }
@@ -74,18 +75,19 @@ impl From<Enum16> for u64 {
         u16::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,
     pub b: Enum16,
     pub payload: Vec<u8>,
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FooChild {
     Bar(Bar),
     Baz(Baz),
+    #[default]
     None,
 }
 impl Foo {
@@ -170,7 +172,7 @@ impl Packet for Foo {
         Ok((Self { payload, a, b }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: u8,
@@ -270,7 +272,7 @@ impl Packet for Bar {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Baz {
     pub y: u16,

--- a/pdl-compiler/tests/generated/rust/packet_decl_child_packets_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_child_packets_little_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
 pub enum Enum16 {
+    #[default]
     A = 0x1,
     B = 0x2,
 }
@@ -74,18 +75,19 @@ impl From<Enum16> for u64 {
         u16::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,
     pub b: Enum16,
     pub payload: Vec<u8>,
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FooChild {
     Bar(Bar),
     Baz(Baz),
+    #[default]
     None,
 }
 impl Foo {
@@ -170,7 +172,7 @@ impl Packet for Foo {
         Ok((Self { payload, a, b }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: u8,
@@ -270,7 +272,7 @@ impl Packet for Bar {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Baz {
     pub y: u16,

--- a/pdl-compiler/tests/generated/rust/packet_decl_complex_scalars_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_complex_scalars_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,

--- a/pdl-compiler/tests/generated/rust/packet_decl_complex_scalars_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_complex_scalars_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,

--- a/pdl-compiler/tests/generated/rust/packet_decl_custom_field_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_custom_field_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u32", into = "u32"))]
 pub struct Bar1(u32);
@@ -62,7 +62,7 @@ impl TryFrom<u32> for Bar1 {
         if value > 0xff_ffff { Err(value) } else { Ok(Bar1(value)) }
     }
 }
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(from = "u32", into = "u32"))]
 pub struct Bar2(u32);
@@ -100,7 +100,7 @@ impl From<u32> for Bar2 {
         Bar2(value)
     }
 }
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(from = "u64", into = "u64"))]
 pub struct Bar3(u64);
@@ -138,7 +138,7 @@ impl From<u64> for Bar3 {
         Bar3(value)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: Bar1,

--- a/pdl-compiler/tests/generated/rust/packet_decl_custom_field_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_custom_field_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u32", into = "u32"))]
 pub struct Bar1(u32);
@@ -62,7 +62,7 @@ impl TryFrom<u32> for Bar1 {
         if value > 0xff_ffff { Err(value) } else { Ok(Bar1(value)) }
     }
 }
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(from = "u32", into = "u32"))]
 pub struct Bar2(u32);
@@ -100,7 +100,7 @@ impl From<u32> for Bar2 {
         Bar2(value)
     }
 }
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(from = "u64", into = "u64"))]
 pub struct Bar3(u64);
@@ -138,7 +138,7 @@ impl From<u64> for Bar3 {
         Bar3(value)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: Bar1,

--- a/pdl-compiler/tests/generated/rust/packet_decl_empty_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_empty_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {}
 impl Foo {}

--- a/pdl-compiler/tests/generated/rust/packet_decl_empty_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_empty_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {}
 impl Foo {}

--- a/pdl-compiler/tests/generated/rust/packet_decl_fixed_enum_field_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_fixed_enum_field_big_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Enum7 {
+    #[default]
     A = 0x1,
     B = 0x2,
 }
@@ -89,7 +90,7 @@ impl From<Enum7> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub b: u64,

--- a/pdl-compiler/tests/generated/rust/packet_decl_fixed_enum_field_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_fixed_enum_field_little_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Enum7 {
+    #[default]
     A = 0x1,
     B = 0x2,
 }
@@ -89,7 +90,7 @@ impl From<Enum7> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub b: u64,

--- a/pdl-compiler/tests/generated/rust/packet_decl_fixed_scalar_field_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_fixed_scalar_field_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub b: u64,

--- a/pdl-compiler/tests/generated/rust/packet_decl_fixed_scalar_field_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_fixed_scalar_field_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub b: u64,

--- a/pdl-compiler/tests/generated/rust/packet_decl_grand_children_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_grand_children_big_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
 pub enum Enum16 {
+    #[default]
     A = 0x1,
     B = 0x2,
 }
@@ -74,7 +75,7 @@ impl From<Enum16> for u64 {
         u16::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parent {
     pub foo: Enum16,
@@ -82,10 +83,11 @@ pub struct Parent {
     pub baz: Enum16,
     pub payload: Vec<u8>,
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ParentChild {
     Child(Child),
+    #[default]
     None,
 }
 impl Parent {
@@ -197,7 +199,7 @@ impl Packet for Parent {
         Ok((Self { payload, foo, bar, baz }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Child {
     pub quux: Enum16,
@@ -236,10 +238,11 @@ impl TryFrom<Parent> for Child {
         (&parent).try_into()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ChildChild {
     GrandChild(GrandChild),
+    #[default]
     None,
 }
 impl Child {
@@ -337,7 +340,7 @@ impl Packet for Child {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrandChild {
     pub baz: Enum16,
@@ -398,10 +401,11 @@ impl TryFrom<Parent> for GrandChild {
         (&packet).try_into()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum GrandChildChild {
     GrandGrandChild(GrandGrandChild),
+    #[default]
     None,
 }
 impl GrandChild {
@@ -486,7 +490,7 @@ impl Packet for GrandChild {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrandGrandChild {
     pub payload: Vec<u8>,

--- a/pdl-compiler/tests/generated/rust/packet_decl_grand_children_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_grand_children_little_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
 pub enum Enum16 {
+    #[default]
     A = 0x1,
     B = 0x2,
 }
@@ -74,7 +75,7 @@ impl From<Enum16> for u64 {
         u16::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parent {
     pub foo: Enum16,
@@ -82,10 +83,11 @@ pub struct Parent {
     pub baz: Enum16,
     pub payload: Vec<u8>,
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ParentChild {
     Child(Child),
+    #[default]
     None,
 }
 impl Parent {
@@ -197,7 +199,7 @@ impl Packet for Parent {
         Ok((Self { payload, foo, bar, baz }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Child {
     pub quux: Enum16,
@@ -236,10 +238,11 @@ impl TryFrom<Parent> for Child {
         (&parent).try_into()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ChildChild {
     GrandChild(GrandChild),
+    #[default]
     None,
 }
 impl Child {
@@ -337,7 +340,7 @@ impl Packet for Child {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrandChild {
     pub baz: Enum16,
@@ -398,10 +401,11 @@ impl TryFrom<Parent> for GrandChild {
         (&packet).try_into()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum GrandChildChild {
     GrandGrandChild(GrandGrandChild),
+    #[default]
     None,
 }
 impl GrandChild {
@@ -486,7 +490,7 @@ impl Packet for GrandChild {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrandGrandChild {
     pub payload: Vec<u8>,

--- a/pdl-compiler/tests/generated/rust/packet_decl_mask_scalar_value_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_mask_scalar_value_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,

--- a/pdl-compiler/tests/generated/rust/packet_decl_mask_scalar_value_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_mask_scalar_value_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,

--- a/pdl-compiler/tests/generated/rust/packet_decl_mixed_scalars_enums_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_mixed_scalars_enums_big_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Enum7 {
+    #[default]
     A = 0x1,
     B = 0x2,
 }
@@ -90,10 +91,11 @@ impl From<Enum7> for u64 {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
 pub enum Enum9 {
+    #[default]
     A = 0x1,
     B = 0x2,
 }
@@ -145,7 +147,7 @@ impl From<Enum9> for u64 {
         u16::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: Enum7,

--- a/pdl-compiler/tests/generated/rust/packet_decl_mixed_scalars_enums_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_mixed_scalars_enums_little_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Enum7 {
+    #[default]
     A = 0x1,
     B = 0x2,
 }
@@ -90,10 +91,11 @@ impl From<Enum7> for u64 {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
 pub enum Enum9 {
+    #[default]
     A = 0x1,
     B = 0x2,
 }
@@ -145,7 +147,7 @@ impl From<Enum9> for u64 {
         u16::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: Enum7,

--- a/pdl-compiler/tests/generated/rust/packet_decl_parent_with_alias_child_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_parent_with_alias_child_big_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Enum8 {
+    #[default]
     A = 0x0,
     B = 0x1,
     C = 0x2,
@@ -87,17 +88,18 @@ impl From<Enum8> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parent {
     pub v: Enum8,
     pub payload: Vec<u8>,
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ParentChild {
     AliasChild(AliasChild),
     NormalChild(NormalChild),
+    #[default]
     None,
 }
 impl Parent {
@@ -146,7 +148,7 @@ impl Packet for Parent {
         Ok((Self { payload, v }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AliasChild {
     pub v: Enum8,
@@ -178,11 +180,12 @@ impl TryFrom<Parent> for AliasChild {
         (&parent).try_into()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AliasChildChild {
     NormalGrandChild1(NormalGrandChild1),
     NormalGrandChild2(NormalGrandChild2),
+    #[default]
     None,
 }
 impl AliasChild {
@@ -231,7 +234,7 @@ impl Packet for AliasChild {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NormalChild {}
 impl TryFrom<&NormalChild> for Parent {
@@ -295,7 +298,7 @@ impl Packet for NormalChild {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NormalGrandChild1 {}
 impl TryFrom<&NormalGrandChild1> for AliasChild {
@@ -383,7 +386,7 @@ impl Packet for NormalGrandChild1 {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NormalGrandChild2 {
     pub payload: Vec<u8>,

--- a/pdl-compiler/tests/generated/rust/packet_decl_parent_with_alias_child_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_parent_with_alias_child_little_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Enum8 {
+    #[default]
     A = 0x0,
     B = 0x1,
     C = 0x2,
@@ -87,17 +88,18 @@ impl From<Enum8> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parent {
     pub v: Enum8,
     pub payload: Vec<u8>,
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ParentChild {
     AliasChild(AliasChild),
     NormalChild(NormalChild),
+    #[default]
     None,
 }
 impl Parent {
@@ -146,7 +148,7 @@ impl Packet for Parent {
         Ok((Self { payload, v }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AliasChild {
     pub v: Enum8,
@@ -178,11 +180,12 @@ impl TryFrom<Parent> for AliasChild {
         (&parent).try_into()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AliasChildChild {
     NormalGrandChild1(NormalGrandChild1),
     NormalGrandChild2(NormalGrandChild2),
+    #[default]
     None,
 }
 impl AliasChild {
@@ -231,7 +234,7 @@ impl Packet for AliasChild {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NormalChild {}
 impl TryFrom<&NormalChild> for Parent {
@@ -295,7 +298,7 @@ impl Packet for NormalChild {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NormalGrandChild1 {}
 impl TryFrom<&NormalGrandChild1> for AliasChild {
@@ -383,7 +386,7 @@ impl Packet for NormalGrandChild1 {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NormalGrandChild2 {
     pub payload: Vec<u8>,

--- a/pdl-compiler/tests/generated/rust/packet_decl_parent_with_no_payload_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_parent_with_no_payload_big_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Enum8 {
+    #[default]
     A = 0x0,
 }
 impl TryFrom<u8> for Enum8 {
@@ -81,15 +82,16 @@ impl From<Enum8> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parent {
     pub v: Enum8,
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ParentChild {
     Child(Child),
+    #[default]
     None,
 }
 impl Parent {
@@ -131,7 +133,7 @@ impl Packet for Parent {
         Ok((Self { v }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Child {}
 impl From<&Child> for Parent {

--- a/pdl-compiler/tests/generated/rust/packet_decl_parent_with_no_payload_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_parent_with_no_payload_little_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Enum8 {
+    #[default]
     A = 0x0,
 }
 impl TryFrom<u8> for Enum8 {
@@ -81,15 +82,16 @@ impl From<Enum8> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parent {
     pub v: Enum8,
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ParentChild {
     Child(Child),
+    #[default]
     None,
 }
 impl Parent {
@@ -131,7 +133,7 @@ impl Packet for Parent {
         Ok((Self { v }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Child {}
 impl From<&Child> for Parent {

--- a/pdl-compiler/tests/generated/rust/packet_decl_payload_field_unknown_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_payload_field_unknown_size_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u32,

--- a/pdl-compiler/tests/generated/rust/packet_decl_payload_field_unknown_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_payload_field_unknown_size_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u32,

--- a/pdl-compiler/tests/generated/rust/packet_decl_payload_field_unknown_size_terminal_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_payload_field_unknown_size_terminal_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u32,

--- a/pdl-compiler/tests/generated/rust/packet_decl_payload_field_unknown_size_terminal_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_payload_field_unknown_size_terminal_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u32,

--- a/pdl-compiler/tests/generated/rust/packet_decl_payload_field_variable_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_payload_field_variable_size_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,

--- a/pdl-compiler/tests/generated/rust/packet_decl_payload_field_variable_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_payload_field_variable_size_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,

--- a/pdl-compiler/tests/generated/rust/packet_decl_reserved_field_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_reserved_field_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {}
 impl Foo {}

--- a/pdl-compiler/tests/generated/rust/packet_decl_reserved_field_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_reserved_field_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {}
 impl Foo {}

--- a/pdl-compiler/tests/generated/rust/packet_decl_simple_scalars_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_simple_scalars_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: u8,

--- a/pdl-compiler/tests/generated/rust/packet_decl_simple_scalars_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_simple_scalars_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: u8,

--- a/pdl-compiler/tests/generated/rust/payload_with_size_modifier_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/payload_with_size_modifier_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Test {
     pub payload: Vec<u8>,

--- a/pdl-compiler/tests/generated/rust/payload_with_size_modifier_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/payload_with_size_modifier_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Test {
     pub payload: Vec<u8>,

--- a/pdl-compiler/tests/generated/rust/reserved_identifier_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/reserved_identifier_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Test {
     pub r#type: u8,

--- a/pdl-compiler/tests/generated/rust/reserved_identifier_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/reserved_identifier_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Test {
     pub r#type: u8,

--- a/pdl-compiler/tests/generated/rust/struct_decl_child_structs_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/struct_decl_child_structs_big_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
 pub enum Enum16 {
+    #[default]
     A = 0x1,
     B = 0x2,
 }
@@ -74,18 +75,19 @@ impl From<Enum16> for u64 {
         u16::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,
     pub b: Enum16,
     pub payload: Vec<u8>,
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FooChild {
     Bar(Bar),
     Baz(Baz),
+    #[default]
     None,
 }
 impl Foo {
@@ -171,7 +173,7 @@ impl Packet for Foo {
         Ok((Self { payload, a, b }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: u8,
@@ -271,7 +273,7 @@ impl Packet for Bar {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Baz {
     pub y: u16,

--- a/pdl-compiler/tests/generated/rust/struct_decl_child_structs_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/struct_decl_child_structs_little_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
 pub enum Enum16 {
+    #[default]
     A = 0x1,
     B = 0x2,
 }
@@ -74,18 +75,19 @@ impl From<Enum16> for u64 {
         u16::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,
     pub b: Enum16,
     pub payload: Vec<u8>,
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FooChild {
     Bar(Bar),
     Baz(Baz),
+    #[default]
     None,
 }
 impl Foo {
@@ -171,7 +173,7 @@ impl Packet for Foo {
         Ok((Self { payload, a, b }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: u8,
@@ -271,7 +273,7 @@ impl Packet for Bar {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Baz {
     pub y: u16,

--- a/pdl-compiler/tests/generated/rust/struct_decl_complex_scalars_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/struct_decl_complex_scalars_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,

--- a/pdl-compiler/tests/generated/rust/struct_decl_complex_scalars_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/struct_decl_complex_scalars_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,

--- a/pdl-compiler/tests/generated/rust/struct_decl_grand_children_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/struct_decl_grand_children_big_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
 pub enum Enum16 {
+    #[default]
     A = 0x1,
     B = 0x2,
 }
@@ -74,7 +75,7 @@ impl From<Enum16> for u64 {
         u16::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parent {
     pub foo: Enum16,
@@ -82,10 +83,11 @@ pub struct Parent {
     pub baz: Enum16,
     pub payload: Vec<u8>,
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ParentChild {
     Child(Child),
+    #[default]
     None,
 }
 impl Parent {
@@ -198,7 +200,7 @@ impl Packet for Parent {
         Ok((Self { payload, foo, bar, baz }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Child {
     pub quux: Enum16,
@@ -237,10 +239,11 @@ impl TryFrom<Parent> for Child {
         (&parent).try_into()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ChildChild {
     GrandChild(GrandChild),
+    #[default]
     None,
 }
 impl Child {
@@ -339,7 +342,7 @@ impl Packet for Child {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrandChild {
     pub baz: Enum16,
@@ -400,10 +403,11 @@ impl TryFrom<Parent> for GrandChild {
         (&packet).try_into()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum GrandChildChild {
     GrandGrandChild(GrandGrandChild),
+    #[default]
     None,
 }
 impl GrandChild {
@@ -489,7 +493,7 @@ impl Packet for GrandChild {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrandGrandChild {
     pub payload: Vec<u8>,

--- a/pdl-compiler/tests/generated/rust/struct_decl_grand_children_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/struct_decl_grand_children_little_endian.rs
@@ -24,10 +24,11 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
 pub enum Enum16 {
+    #[default]
     A = 0x1,
     B = 0x2,
 }
@@ -74,7 +75,7 @@ impl From<Enum16> for u64 {
         u16::from(value) as Self
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parent {
     pub foo: Enum16,
@@ -82,10 +83,11 @@ pub struct Parent {
     pub baz: Enum16,
     pub payload: Vec<u8>,
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ParentChild {
     Child(Child),
+    #[default]
     None,
 }
 impl Parent {
@@ -198,7 +200,7 @@ impl Packet for Parent {
         Ok((Self { payload, foo, bar, baz }, buf))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Child {
     pub quux: Enum16,
@@ -237,10 +239,11 @@ impl TryFrom<Parent> for Child {
         (&parent).try_into()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ChildChild {
     GrandChild(GrandChild),
+    #[default]
     None,
 }
 impl Child {
@@ -339,7 +342,7 @@ impl Packet for Child {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrandChild {
     pub baz: Enum16,
@@ -400,10 +403,11 @@ impl TryFrom<Parent> for GrandChild {
         (&packet).try_into()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum GrandChildChild {
     GrandGrandChild(GrandGrandChild),
+    #[default]
     None,
 }
 impl GrandChild {
@@ -489,7 +493,7 @@ impl Packet for GrandChild {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrandGrandChild {
     pub payload: Vec<u8>,


### PR DESCRIPTION
Default trait is useful when creating proof-of-concept tools.

Fixes #146 