### PR TITLE
Fix nondeterministic outputs of pdl compiler

### DIFF
--- a/pdl-compiler/src/backends/java/codegen/packet.rs
+++ b/pdl-compiler/src/backends/java/codegen/packet.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use genco::{self, prelude::Java, quote, tokens::quoted, Tokens};
 use heck::{self, ToLowerCamelCase, ToUpperCamelCase};
@@ -142,7 +142,7 @@ pub fn gen_packet(name: &String, def: &PacketDef, ctx: &Context) -> Tokens<Java>
 
                 $(setter_defs(
                     &def.members, &quote!(Builder),
-                    &HashMap::new(), &def.width_fields, &ctx.heirarchy))
+                    &BTreeMap::new(), &def.width_fields, &ctx.heirarchy))
             }
         }
     }
@@ -266,7 +266,7 @@ pub fn gen_abstract_packet(
             }
 
             protected abstract static class UnconstrainedBuilder<B extends Builder<B>> extends Builder<B> {
-                $(setter_defs(&def.members, &quote!(B), &HashMap::new(), &def.width_fields, &ctx.heirarchy))
+                $(setter_defs(&def.members, &quote!(B), &BTreeMap::new(), &def.width_fields, &ctx.heirarchy))
             }
 
             $(for child in children.iter() {
@@ -319,7 +319,7 @@ fn getter_defs(members: &[Field]) -> Tokens<Java> {
 fn setter_defs(
     members: &[Field],
     builder_type: &Tokens<Java>,
-    constraints: &HashMap<String, Constraint>,
+    constraints: &BTreeMap<String, Constraint>,
     width_fields: &HashMap<String, WidthField>,
     heirarchy: &ClassHeirarchy,
 ) -> Tokens<Java> {

--- a/pdl-compiler/src/backends/java/inheritance.rs
+++ b/pdl-compiler/src/backends/java/inheritance.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::backends::java::Field;
 
@@ -27,7 +27,7 @@ pub struct InheritanceNode {
     pub name: String,
     pub parent: Option<String>,
     pub children: Vec<String>,
-    pub constraints: HashMap<String, Constraint>,
+    pub constraints: BTreeMap<String, Constraint>,
     pub static_field_width: usize,
     pub dyn_fields: HashSet<String>,
 }
@@ -64,7 +64,7 @@ impl ClassHeirarchy {
                 name,
                 parent: None,
                 children: Vec::new(),
-                constraints: HashMap::new(),
+                constraints: BTreeMap::new(),
                 static_field_width,
                 dyn_fields: non_static_members,
             },
@@ -75,7 +75,7 @@ impl ClassHeirarchy {
         &mut self,
         parent_name: String,
         child_name: String,
-        constraints: HashMap<String, Constraint>,
+        constraints: BTreeMap<String, Constraint>,
         fields: &Vec<Field>,
     ) {
         self.0

--- a/pdl-compiler/src/backends/java/mod.rs
+++ b/pdl-compiler/src/backends/java/mod.rs
@@ -21,6 +21,7 @@ use genco::{
 use heck::{self, ToLowerCamelCase, ToUpperCamelCase};
 use std::{
     cmp,
+    collections::BTreeMap,
     collections::HashMap,
     fs::{self, OpenOptions},
     iter, mem,
@@ -137,7 +138,7 @@ fn generate_classes(file: &ast::File) -> (HashMap<String, Class>, ClassHeirarchy
                     heirarchy.add_child(
                         parent_name.clone(),
                         child_name.clone(),
-                        HashMap::new(),
+                        BTreeMap::new(),
                         child.fields().unwrap(),
                     );
 


### PR DESCRIPTION
Due to unordered traversal of HashMap, the generated java code is non deterministic. This is bad from the perspective of build systems, since it causes unnecessary rebuilds if the iteration order changes.

This CL switches a data structure to BTreeMap to fix the non determinism