### PR TITLE
Manually implement the Default trait for generated types

### DIFF
--- a/pdl-compiler/src/backends.rs
+++ b/pdl-compiler/src/backends.rs
@@ -20,4 +20,4 @@ pub mod json;
 pub mod rust;
 pub mod rust_legacy;
 
-mod common;
+pub mod common;

--- a/pdl-compiler/src/backends/common/alignment.rs
+++ b/pdl-compiler/src/backends/common/alignment.rs
@@ -60,7 +60,7 @@ pub enum Chunk<S: Symbol> {
 }
 
 /// Packs symbols of various sizes, which may not be byte-aligned, into a sequence of byte-aligned chunks.
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct ByteAligner<S: Symbol> {
     /// Staged fields, waiting to be packed into a chunk.
     staged_fields: Vec<Field<S>>,

--- a/pdl-compiler/src/main.rs
+++ b/pdl-compiler/src/main.rs
@@ -14,8 +14,6 @@
 
 //! PDL parser and analyzer.
 
-use std::path::Path;
-
 use argh::FromArgs;
 use codespan_reporting::term::{self, termcolor};
 
@@ -80,11 +78,13 @@ struct Opt {
     /// For the rust backend this is a path e.g. "module::CustomField" or "super::CustomField".
     custom_field: Vec<String>,
 
+    #[cfg(feature = "java")]
     #[argh(option)]
     /// directory where generated files should go. This only works when 'output_format' is 'java'.
     /// If omitted, the generated code will be printed to stdout.
     output_dir: Option<String>,
 
+    #[cfg(feature = "java")]
     #[argh(option)]
     /// java package to contain the generated classes.
     java_package: Option<String>,
@@ -149,7 +149,7 @@ fn generate_backend(opt: &Opt) -> Result<(), String> {
                         &sources,
                         &analyzed_file,
                         &opt.custom_field,
-                        Path::new(output_dir),
+                        std::path::Path::new(output_dir),
                         package,
                     )
                 }
@@ -167,7 +167,8 @@ fn generate_backend(opt: &Opt) -> Result<(), String> {
         Err(err) => {
             let writer = termcolor::StandardStream::stderr(termcolor::ColorChoice::Always);
             let config = term::Config::default();
-            term::emit_to_write_style(&mut writer.lock(), &config, &sources, &err).expect("Could not print error");
+            term::emit_to_write_style(&mut writer.lock(), &config, &sources, &err)
+                .expect("Could not print error");
             Err(String::from("Error while parsing input"))
         }
     }
@@ -196,7 +197,7 @@ fn generate_tests(opt: &Opt, test_file: &str) -> Result<(), String> {
 
             backends::java::test::generate_tests(
                 test_file,
-                Path::new(output_dir),
+                std::path::Path::new(output_dir),
                 package.clone(),
                 &opt.input_file,
                 &opt.exclude_declaration,

--- a/pdl-compiler/src/parser.rs
+++ b/pdl-compiler/src/parser.rs
@@ -649,8 +649,7 @@ pub fn parse_inline(
 ) -> Result<ast::File, Diagnostic<ast::FileId>> {
     let root = PDLParser::parse(Rule::file, &source)
         .map_err(|e| {
-            Diagnostic::error()
-                .with_message(format!("failed to parse input file '{name}': {e}"))
+            Diagnostic::error().with_message(format!("failed to parse input file '{name}': {e}"))
         })?
         .next()
         .unwrap();

--- a/pdl-compiler/tests/generated/rust/enum_declaration_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/enum_declaration_big_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum IncompleteTruncatedClosed {
-    #[default]
     A = 0x0,
     B = 0x1,
+}
+impl Default for IncompleteTruncatedClosed {
+    fn default() -> IncompleteTruncatedClosed {
+        IncompleteTruncatedClosed::A
+    }
 }
 impl TryFrom<u8> for IncompleteTruncatedClosed {
     type Error = u8;
@@ -90,14 +94,18 @@ impl From<IncompleteTruncatedClosed> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum IncompleteTruncatedOpen {
-    #[default]
     A,
     B,
     Unknown(Private<u8>),
+}
+impl Default for IncompleteTruncatedOpen {
+    fn default() -> IncompleteTruncatedOpen {
+        IncompleteTruncatedOpen::A
+    }
 }
 impl TryFrom<u8> for IncompleteTruncatedOpen {
     type Error = u8;
@@ -159,15 +167,19 @@ impl From<IncompleteTruncatedOpen> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum IncompleteTruncatedClosedWithRange {
-    #[default]
     A,
     X,
     Y,
     B(Private<u8>),
+}
+impl Default for IncompleteTruncatedClosedWithRange {
+    fn default() -> IncompleteTruncatedClosedWithRange {
+        IncompleteTruncatedClosedWithRange::A
+    }
 }
 impl TryFrom<u8> for IncompleteTruncatedClosedWithRange {
     type Error = u8;
@@ -231,16 +243,20 @@ impl From<IncompleteTruncatedClosedWithRange> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum IncompleteTruncatedOpenWithRange {
-    #[default]
     A,
     X,
     Y,
     B(Private<u8>),
     Unknown(Private<u8>),
+}
+impl Default for IncompleteTruncatedOpenWithRange {
+    fn default() -> IncompleteTruncatedOpenWithRange {
+        IncompleteTruncatedOpenWithRange::A
+    }
 }
 impl TryFrom<u8> for IncompleteTruncatedOpenWithRange {
     type Error = u8;
@@ -307,11 +323,10 @@ impl From<IncompleteTruncatedOpenWithRange> for u64 {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum CompleteTruncated {
-    #[default]
     A = 0x0,
     B = 0x1,
     C = 0x2,
@@ -320,6 +335,11 @@ pub enum CompleteTruncated {
     F = 0x5,
     G = 0x6,
     H = 0x7,
+}
+impl Default for CompleteTruncated {
+    fn default() -> CompleteTruncated {
+        CompleteTruncated::A
+    }
 }
 impl TryFrom<u8> for CompleteTruncated {
     type Error = u8;
@@ -391,15 +411,19 @@ impl From<CompleteTruncated> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum CompleteTruncatedWithRange {
-    #[default]
     A,
     X,
     Y,
     B(Private<u8>),
+}
+impl Default for CompleteTruncatedWithRange {
+    fn default() -> CompleteTruncatedWithRange {
+        CompleteTruncatedWithRange::A
+    }
 }
 impl TryFrom<u8> for CompleteTruncatedWithRange {
     type Error = u8;
@@ -463,14 +487,18 @@ impl From<CompleteTruncatedWithRange> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum CompleteWithRange {
-    #[default]
     A,
     B,
     C(Private<u8>),
+}
+impl Default for CompleteWithRange {
+    fn default() -> CompleteWithRange {
+        CompleteWithRange::A
+    }
 }
 impl TryFrom<u8> for CompleteWithRange {
     type Error = u8;

--- a/pdl-compiler/tests/generated/rust/enum_declaration_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/enum_declaration_little_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum IncompleteTruncatedClosed {
-    #[default]
     A = 0x0,
     B = 0x1,
+}
+impl Default for IncompleteTruncatedClosed {
+    fn default() -> IncompleteTruncatedClosed {
+        IncompleteTruncatedClosed::A
+    }
 }
 impl TryFrom<u8> for IncompleteTruncatedClosed {
     type Error = u8;
@@ -90,14 +94,18 @@ impl From<IncompleteTruncatedClosed> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum IncompleteTruncatedOpen {
-    #[default]
     A,
     B,
     Unknown(Private<u8>),
+}
+impl Default for IncompleteTruncatedOpen {
+    fn default() -> IncompleteTruncatedOpen {
+        IncompleteTruncatedOpen::A
+    }
 }
 impl TryFrom<u8> for IncompleteTruncatedOpen {
     type Error = u8;
@@ -159,15 +167,19 @@ impl From<IncompleteTruncatedOpen> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum IncompleteTruncatedClosedWithRange {
-    #[default]
     A,
     X,
     Y,
     B(Private<u8>),
+}
+impl Default for IncompleteTruncatedClosedWithRange {
+    fn default() -> IncompleteTruncatedClosedWithRange {
+        IncompleteTruncatedClosedWithRange::A
+    }
 }
 impl TryFrom<u8> for IncompleteTruncatedClosedWithRange {
     type Error = u8;
@@ -231,16 +243,20 @@ impl From<IncompleteTruncatedClosedWithRange> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum IncompleteTruncatedOpenWithRange {
-    #[default]
     A,
     X,
     Y,
     B(Private<u8>),
     Unknown(Private<u8>),
+}
+impl Default for IncompleteTruncatedOpenWithRange {
+    fn default() -> IncompleteTruncatedOpenWithRange {
+        IncompleteTruncatedOpenWithRange::A
+    }
 }
 impl TryFrom<u8> for IncompleteTruncatedOpenWithRange {
     type Error = u8;
@@ -307,11 +323,10 @@ impl From<IncompleteTruncatedOpenWithRange> for u64 {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum CompleteTruncated {
-    #[default]
     A = 0x0,
     B = 0x1,
     C = 0x2,
@@ -320,6 +335,11 @@ pub enum CompleteTruncated {
     F = 0x5,
     G = 0x6,
     H = 0x7,
+}
+impl Default for CompleteTruncated {
+    fn default() -> CompleteTruncated {
+        CompleteTruncated::A
+    }
 }
 impl TryFrom<u8> for CompleteTruncated {
     type Error = u8;
@@ -391,15 +411,19 @@ impl From<CompleteTruncated> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum CompleteTruncatedWithRange {
-    #[default]
     A,
     X,
     Y,
     B(Private<u8>),
+}
+impl Default for CompleteTruncatedWithRange {
+    fn default() -> CompleteTruncatedWithRange {
+        CompleteTruncatedWithRange::A
+    }
 }
 impl TryFrom<u8> for CompleteTruncatedWithRange {
     type Error = u8;
@@ -463,14 +487,18 @@ impl From<CompleteTruncatedWithRange> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum CompleteWithRange {
-    #[default]
     A,
     B,
     C(Private<u8>),
+}
+impl Default for CompleteWithRange {
+    fn default() -> CompleteWithRange {
+        CompleteWithRange::A
+    }
 }
 impl TryFrom<u8> for CompleteWithRange {
     type Error = u8;

--- a/pdl-compiler/tests/generated/rust/packet_decl_24bit_enum_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_24bit_enum_array_big_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u32", into = "u32"))]
 pub enum Foo {
-    #[default]
     FooBar = 0x1,
     Baz = 0x2,
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo::FooBar
+    }
 }
 impl TryFrom<u32> for Foo {
     type Error = u32;
@@ -70,7 +74,7 @@ impl From<Foo> for u64 {
         u32::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: [Foo; 5],
@@ -78,6 +82,13 @@ pub struct Bar {
 impl Bar {
     pub fn x(&self) -> &[Foo; 5] {
         &self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar {
+            x: std::array::from_fn(|_| Default::default()),
+        }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_24bit_enum_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_24bit_enum_array_little_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u32", into = "u32"))]
 pub enum Foo {
-    #[default]
     FooBar = 0x1,
     Baz = 0x2,
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo::FooBar
+    }
 }
 impl TryFrom<u32> for Foo {
     type Error = u32;
@@ -70,7 +74,7 @@ impl From<Foo> for u64 {
         u32::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: [Foo; 5],
@@ -78,6 +82,13 @@ pub struct Bar {
 impl Bar {
     pub fn x(&self) -> &[Foo; 5] {
         &self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar {
+            x: std::array::from_fn(|_| Default::default()),
+        }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_24bit_enum_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_24bit_enum_big_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u32", into = "u32"))]
 pub enum Foo {
-    #[default]
     A = 0x1,
     B = 0x2,
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo::A
+    }
 }
 impl TryFrom<u32> for Foo {
     type Error = u32;
@@ -70,7 +74,7 @@ impl From<Foo> for u64 {
         u32::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Foo,
@@ -78,6 +82,11 @@ pub struct Bar {
 impl Bar {
     pub fn x(&self) -> Foo {
         self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar { x: Default::default() }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_24bit_enum_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_24bit_enum_little_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u32", into = "u32"))]
 pub enum Foo {
-    #[default]
     A = 0x1,
     B = 0x2,
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo::A
+    }
 }
 impl TryFrom<u32> for Foo {
     type Error = u32;
@@ -70,7 +74,7 @@ impl From<Foo> for u64 {
         u32::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Foo,
@@ -78,6 +82,11 @@ pub struct Bar {
 impl Bar {
     pub fn x(&self) -> Foo {
         self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar { x: Default::default() }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_24bit_scalar_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_24bit_scalar_array_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: [u32; 5],
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn x(&self) -> &[u32; 5] {
         &self.x
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { x: [0; 5usize] }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_24bit_scalar_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_24bit_scalar_array_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: [u32; 5],
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn x(&self) -> &[u32; 5] {
         &self.x
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { x: [0; 5usize] }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_24bit_scalar_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_24bit_scalar_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: u32,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn x(&self) -> u32 {
         self.x
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { x: 0 }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_24bit_scalar_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_24bit_scalar_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: u32,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn x(&self) -> u32 {
         self.x
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { x: 0 }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_64bit_enum_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_64bit_enum_array_big_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u64", into = "u64"))]
 pub enum Foo {
-    #[default]
     FooBar = 0x1,
     Baz = 0x2,
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo::FooBar
+    }
 }
 impl TryFrom<u64> for Foo {
     type Error = u64;
@@ -55,7 +59,7 @@ impl From<Foo> for u64 {
         (&value).into()
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: [Foo; 7],
@@ -63,6 +67,13 @@ pub struct Bar {
 impl Bar {
     pub fn x(&self) -> &[Foo; 7] {
         &self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar {
+            x: std::array::from_fn(|_| Default::default()),
+        }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_64bit_enum_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_64bit_enum_array_little_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u64", into = "u64"))]
 pub enum Foo {
-    #[default]
     FooBar = 0x1,
     Baz = 0x2,
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo::FooBar
+    }
 }
 impl TryFrom<u64> for Foo {
     type Error = u64;
@@ -55,7 +59,7 @@ impl From<Foo> for u64 {
         (&value).into()
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: [Foo; 7],
@@ -63,6 +67,13 @@ pub struct Bar {
 impl Bar {
     pub fn x(&self) -> &[Foo; 7] {
         &self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar {
+            x: std::array::from_fn(|_| Default::default()),
+        }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_64bit_enum_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_64bit_enum_big_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u64", into = "u64"))]
 pub enum Foo {
-    #[default]
     A = 0x1,
     B = 0x2,
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo::A
+    }
 }
 impl TryFrom<u64> for Foo {
     type Error = u64;
@@ -55,7 +59,7 @@ impl From<Foo> for u64 {
         (&value).into()
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Foo,
@@ -63,6 +67,11 @@ pub struct Bar {
 impl Bar {
     pub fn x(&self) -> Foo {
         self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar { x: Default::default() }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_64bit_enum_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_64bit_enum_little_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u64", into = "u64"))]
 pub enum Foo {
-    #[default]
     A = 0x1,
     B = 0x2,
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo::A
+    }
 }
 impl TryFrom<u64> for Foo {
     type Error = u64;
@@ -55,7 +59,7 @@ impl From<Foo> for u64 {
         (&value).into()
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Foo,
@@ -63,6 +67,11 @@ pub struct Bar {
 impl Bar {
     pub fn x(&self) -> Foo {
         self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar { x: Default::default() }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_64bit_scalar_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_64bit_scalar_array_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: [u64; 7],
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn x(&self) -> &[u64; 7] {
         &self.x
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { x: [0; 7usize] }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_64bit_scalar_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_64bit_scalar_array_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: [u64; 7],
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn x(&self) -> &[u64; 7] {
         &self.x
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { x: [0; 7usize] }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_64bit_scalar_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_64bit_scalar_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: u64,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn x(&self) -> u64 {
         self.x
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { x: 0 }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_64bit_scalar_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_64bit_scalar_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: u64,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn x(&self) -> u64 {
         self.x
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { x: 0 }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_8bit_enum_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_8bit_enum_array_big_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Foo {
-    #[default]
     FooBar = 0x1,
     Baz = 0x2,
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo::FooBar
+    }
 }
 impl TryFrom<u8> for Foo {
     type Error = u8;
@@ -85,7 +89,7 @@ impl From<Foo> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: [Foo; 3],
@@ -93,6 +97,13 @@ pub struct Bar {
 impl Bar {
     pub fn x(&self) -> &[Foo; 3] {
         &self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar {
+            x: std::array::from_fn(|_| Default::default()),
+        }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_8bit_enum_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_8bit_enum_array_little_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Foo {
-    #[default]
     FooBar = 0x1,
     Baz = 0x2,
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo::FooBar
+    }
 }
 impl TryFrom<u8> for Foo {
     type Error = u8;
@@ -85,7 +89,7 @@ impl From<Foo> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: [Foo; 3],
@@ -93,6 +97,13 @@ pub struct Bar {
 impl Bar {
     pub fn x(&self) -> &[Foo; 3] {
         &self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar {
+            x: std::array::from_fn(|_| Default::default()),
+        }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_8bit_enum_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_8bit_enum_big_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Foo {
-    #[default]
     A = 0x1,
     B = 0x2,
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo::A
+    }
 }
 impl TryFrom<u8> for Foo {
     type Error = u8;
@@ -85,7 +89,7 @@ impl From<Foo> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Foo,
@@ -93,6 +97,11 @@ pub struct Bar {
 impl Bar {
     pub fn x(&self) -> Foo {
         self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar { x: Default::default() }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_8bit_enum_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_8bit_enum_little_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Foo {
-    #[default]
     A = 0x1,
     B = 0x2,
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo::A
+    }
 }
 impl TryFrom<u8> for Foo {
     type Error = u8;
@@ -85,7 +89,7 @@ impl From<Foo> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Foo,
@@ -93,6 +97,11 @@ pub struct Bar {
 impl Bar {
     pub fn x(&self) -> Foo {
         self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar { x: Default::default() }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_8bit_scalar_array_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_8bit_scalar_array_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: [u8; 3],
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn x(&self) -> &[u8; 3] {
         &self.x
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { x: [0; 3usize] }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_8bit_scalar_array_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_8bit_scalar_array_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: [u8; 3],
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn x(&self) -> &[u8; 3] {
         &self.x
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { x: [0; 3usize] }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_8bit_scalar_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_8bit_scalar_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: u8,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn x(&self) -> u8 {
         self.x
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { x: 0 }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_8bit_scalar_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_8bit_scalar_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: u8,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn x(&self) -> u8 {
         self.x
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { x: 0 }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_count_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_count_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub padding: u8,
@@ -35,6 +35,11 @@ impl Foo {
     }
     pub fn x(&self) -> &Vec<u32> {
         &self.x
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { padding: 0, x: vec![] }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_count_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_count_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub padding: u8,
@@ -35,6 +35,11 @@ impl Foo {
     }
     pub fn x(&self) -> &Vec<u32> {
         &self.x
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { padding: 0, x: vec![] }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub inner: Vec<u8>,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn inner(&self) -> &Vec<u8> {
         &self.inner
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { inner: vec![] }
     }
 }
 impl Packet for Foo {
@@ -51,7 +56,7 @@ impl Packet for Foo {
         Ok((Self { inner }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub padding: u8,
@@ -63,6 +68,11 @@ impl Bar {
     }
     pub fn x(&self) -> &Vec<Foo> {
         &self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar { padding: 0, x: vec![] }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_dynamic_count_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_dynamic_count_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub inner: Vec<u8>,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn inner(&self) -> &Vec<u8> {
         &self.inner
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { inner: vec![] }
     }
 }
 impl Packet for Foo {
@@ -51,7 +56,7 @@ impl Packet for Foo {
         Ok((Self { inner }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Vec<Foo>,
@@ -59,6 +64,11 @@ pub struct Bar {
 impl Bar {
     pub fn x(&self) -> &Vec<Foo> {
         &self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar { x: vec![] }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_dynamic_count_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_dynamic_count_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub inner: Vec<u8>,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn inner(&self) -> &Vec<u8> {
         &self.inner
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { inner: vec![] }
     }
 }
 impl Packet for Foo {
@@ -51,7 +56,7 @@ impl Packet for Foo {
         Ok((Self { inner }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Vec<Foo>,
@@ -59,6 +64,11 @@ pub struct Bar {
 impl Bar {
     pub fn x(&self) -> &Vec<Foo> {
         &self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar { x: vec![] }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_dynamic_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_dynamic_size_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub inner: Vec<u8>,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn inner(&self) -> &Vec<u8> {
         &self.inner
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { inner: vec![] }
     }
 }
 impl Packet for Foo {
@@ -51,7 +56,7 @@ impl Packet for Foo {
         Ok((Self { inner }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Vec<Foo>,
@@ -59,6 +64,11 @@ pub struct Bar {
 impl Bar {
     pub fn x(&self) -> &Vec<Foo> {
         &self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar { x: vec![] }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_dynamic_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_dynamic_size_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub inner: Vec<u8>,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn inner(&self) -> &Vec<u8> {
         &self.inner
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { inner: vec![] }
     }
 }
 impl Packet for Foo {
@@ -51,7 +56,7 @@ impl Packet for Foo {
         Ok((Self { inner }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Vec<Foo>,
@@ -59,6 +64,11 @@ pub struct Bar {
 impl Bar {
     pub fn x(&self) -> &Vec<Foo> {
         &self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar { x: vec![] }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub inner: Vec<u8>,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn inner(&self) -> &Vec<u8> {
         &self.inner
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { inner: vec![] }
     }
 }
 impl Packet for Foo {
@@ -51,7 +56,7 @@ impl Packet for Foo {
         Ok((Self { inner }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub padding: u8,
@@ -63,6 +68,11 @@ impl Bar {
     }
     pub fn x(&self) -> &Vec<Foo> {
         &self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar { padding: 0, x: vec![] }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_static_count_1_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_static_count_1_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub inner: Vec<u8>,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn inner(&self) -> &Vec<u8> {
         &self.inner
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { inner: vec![] }
     }
 }
 impl Packet for Foo {
@@ -51,7 +56,7 @@ impl Packet for Foo {
         Ok((Self { inner }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub padding: u8,
@@ -63,6 +68,14 @@ impl Bar {
     }
     pub fn x(&self) -> &[Foo; 1] {
         &self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar {
+            padding: 0,
+            x: std::array::from_fn(|_| Default::default()),
+        }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_static_count_1_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_static_count_1_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub inner: Vec<u8>,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn inner(&self) -> &Vec<u8> {
         &self.inner
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { inner: vec![] }
     }
 }
 impl Packet for Foo {
@@ -51,7 +56,7 @@ impl Packet for Foo {
         Ok((Self { inner }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub padding: u8,
@@ -63,6 +68,14 @@ impl Bar {
     }
     pub fn x(&self) -> &[Foo; 1] {
         &self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar {
+            padding: 0,
+            x: std::array::from_fn(|_| Default::default()),
+        }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_static_count_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_static_count_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub inner: Vec<u8>,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn inner(&self) -> &Vec<u8> {
         &self.inner
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { inner: vec![] }
     }
 }
 impl Packet for Foo {
@@ -51,7 +56,7 @@ impl Packet for Foo {
         Ok((Self { inner }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub padding: u8,
@@ -63,6 +68,14 @@ impl Bar {
     }
     pub fn x(&self) -> &[Foo; 4] {
         &self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar {
+            padding: 0,
+            x: std::array::from_fn(|_| Default::default()),
+        }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_static_count_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_static_count_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub inner: Vec<u8>,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn inner(&self) -> &Vec<u8> {
         &self.inner
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { inner: vec![] }
     }
 }
 impl Packet for Foo {
@@ -51,7 +56,7 @@ impl Packet for Foo {
         Ok((Self { inner }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub padding: u8,
@@ -63,6 +68,14 @@ impl Bar {
     }
     pub fn x(&self) -> &[Foo; 4] {
         &self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar {
+            padding: 0,
+            x: std::array::from_fn(|_| Default::default()),
+        }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_size_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub padding: u8,
@@ -35,6 +35,11 @@ impl Foo {
     }
     pub fn x(&self) -> &Vec<u32> {
         &self.x
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { padding: 0, x: vec![] }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_size_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub padding: u8,
@@ -35,6 +35,11 @@ impl Foo {
     }
     pub fn x(&self) -> &Vec<u32> {
         &self.x
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { padding: 0, x: vec![] }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_unknown_element_width_dynamic_count_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_unknown_element_width_dynamic_count_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: Vec<u16>,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn a(&self) -> &Vec<u16> {
         &self.a
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { a: vec![] }
     }
 }
 impl Packet for Foo {
@@ -74,7 +79,7 @@ impl Packet for Foo {
         Ok((Self { a }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Vec<Foo>,
@@ -82,6 +87,11 @@ pub struct Bar {
 impl Bar {
     pub fn x(&self) -> &Vec<Foo> {
         &self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar { x: vec![] }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_unknown_element_width_dynamic_count_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_unknown_element_width_dynamic_count_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: Vec<u16>,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn a(&self) -> &Vec<u16> {
         &self.a
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { a: vec![] }
     }
 }
 impl Packet for Foo {
@@ -74,7 +79,7 @@ impl Packet for Foo {
         Ok((Self { a }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Vec<Foo>,
@@ -82,6 +87,11 @@ pub struct Bar {
 impl Bar {
     pub fn x(&self) -> &Vec<Foo> {
         &self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar { x: vec![] }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_unknown_element_width_dynamic_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_unknown_element_width_dynamic_size_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: Vec<u16>,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn a(&self) -> &Vec<u16> {
         &self.a
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { a: vec![] }
     }
 }
 impl Packet for Foo {
@@ -74,7 +79,7 @@ impl Packet for Foo {
         Ok((Self { a }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Vec<Foo>,
@@ -82,6 +87,11 @@ pub struct Bar {
 impl Bar {
     pub fn x(&self) -> &Vec<Foo> {
         &self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar { x: vec![] }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_unknown_element_width_dynamic_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_unknown_element_width_dynamic_size_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: Vec<u16>,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn a(&self) -> &Vec<u16> {
         &self.a
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { a: vec![] }
     }
 }
 impl Packet for Foo {
@@ -74,7 +79,7 @@ impl Packet for Foo {
         Ok((Self { a }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: Vec<Foo>,
@@ -82,6 +87,11 @@ pub struct Bar {
 impl Bar {
     pub fn x(&self) -> &Vec<Foo> {
         &self.x
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar { x: vec![] }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_with_padding_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_with_padding_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: Vec<u16>,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn a(&self) -> &Vec<u16> {
         &self.a
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { a: vec![] }
     }
 }
 impl Packet for Foo {
@@ -74,7 +79,7 @@ impl Packet for Foo {
         Ok((Self { a }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub a: Vec<Foo>,
@@ -82,6 +87,11 @@ pub struct Bar {
 impl Bar {
     pub fn a(&self) -> &Vec<Foo> {
         &self.a
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar { a: vec![] }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_with_padding_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_with_padding_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: Vec<u16>,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn a(&self) -> &Vec<u16> {
         &self.a
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { a: vec![] }
     }
 }
 impl Packet for Foo {
@@ -74,7 +79,7 @@ impl Packet for Foo {
         Ok((Self { a }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub a: Vec<Foo>,
@@ -82,6 +87,11 @@ pub struct Bar {
 impl Bar {
     pub fn a(&self) -> &Vec<Foo> {
         &self.a
+    }
+}
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar { a: vec![] }
     }
 }
 impl Packet for Bar {

--- a/pdl-compiler/tests/generated/rust/packet_decl_child_packets_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_child_packets_big_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
 pub enum Enum16 {
-    #[default]
     A = 0x1,
     B = 0x2,
+}
+impl Default for Enum16 {
+    fn default() -> Enum16 {
+        Enum16::A
+    }
 }
 impl TryFrom<u16> for Enum16 {
     type Error = u16;
@@ -75,7 +79,7 @@ impl From<Enum16> for u64 {
         u16::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,
@@ -108,6 +112,15 @@ impl Foo {
     }
     pub fn b(&self) -> Enum16 {
         self.b
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo {
+            a: 0,
+            b: Default::default(),
+            payload: vec![],
+        }
     }
 }
 impl Packet for Foo {
@@ -172,7 +185,7 @@ impl Packet for Foo {
         Ok((Self { payload, a, b }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: u8,
@@ -247,6 +260,11 @@ impl Bar {
         100
     }
 }
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar { x: 0, b: Default::default() }
+    }
+}
 impl Packet for Bar {
     fn encoded_len(&self) -> usize {
         5
@@ -272,7 +290,7 @@ impl Packet for Bar {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Baz {
     pub y: u16,
@@ -345,6 +363,11 @@ impl Baz {
     }
     pub fn b(&self) -> Enum16 {
         Enum16::B
+    }
+}
+impl Default for Baz {
+    fn default() -> Baz {
+        Baz { y: 0, a: 0 }
     }
 }
 impl Packet for Baz {

--- a/pdl-compiler/tests/generated/rust/packet_decl_child_packets_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_child_packets_little_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
 pub enum Enum16 {
-    #[default]
     A = 0x1,
     B = 0x2,
+}
+impl Default for Enum16 {
+    fn default() -> Enum16 {
+        Enum16::A
+    }
 }
 impl TryFrom<u16> for Enum16 {
     type Error = u16;
@@ -75,7 +79,7 @@ impl From<Enum16> for u64 {
         u16::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,
@@ -108,6 +112,15 @@ impl Foo {
     }
     pub fn b(&self) -> Enum16 {
         self.b
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo {
+            a: 0,
+            b: Default::default(),
+            payload: vec![],
+        }
     }
 }
 impl Packet for Foo {
@@ -172,7 +185,7 @@ impl Packet for Foo {
         Ok((Self { payload, a, b }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: u8,
@@ -247,6 +260,11 @@ impl Bar {
         100
     }
 }
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar { x: 0, b: Default::default() }
+    }
+}
 impl Packet for Bar {
     fn encoded_len(&self) -> usize {
         5
@@ -272,7 +290,7 @@ impl Packet for Bar {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Baz {
     pub y: u16,
@@ -345,6 +363,11 @@ impl Baz {
     }
     pub fn b(&self) -> Enum16 {
         Enum16::B
+    }
+}
+impl Default for Baz {
+    fn default() -> Baz {
+        Baz { y: 0, a: 0 }
     }
 }
 impl Packet for Baz {

--- a/pdl-compiler/tests/generated/rust/packet_decl_complex_scalars_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_complex_scalars_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,
@@ -51,6 +51,18 @@ impl Foo {
     }
     pub fn f(&self) -> u8 {
         self.f
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo {
+            a: 0,
+            b: 0,
+            c: 0,
+            d: 0,
+            e: 0,
+            f: 0,
+        }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_complex_scalars_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_complex_scalars_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,
@@ -51,6 +51,18 @@ impl Foo {
     }
     pub fn f(&self) -> u8 {
         self.f
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo {
+            a: 0,
+            b: 0,
+            c: 0,
+            d: 0,
+            e: 0,
+            f: 0,
+        }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_custom_field_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_custom_field_big_endian.rs
@@ -138,7 +138,7 @@ impl From<u64> for Bar3 {
         Bar3(value)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: Bar1,
@@ -154,6 +154,15 @@ impl Foo {
     }
     pub fn c(&self) -> Bar3 {
         self.c
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo {
+            a: Default::default(),
+            b: Default::default(),
+            c: Default::default(),
+        }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_custom_field_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_custom_field_little_endian.rs
@@ -138,7 +138,7 @@ impl From<u64> for Bar3 {
         Bar3(value)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: Bar1,
@@ -154,6 +154,15 @@ impl Foo {
     }
     pub fn c(&self) -> Bar3 {
         self.c
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo {
+            a: Default::default(),
+            b: Default::default(),
+            c: Default::default(),
+        }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_empty_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_empty_big_endian.rs
@@ -23,10 +23,15 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {}
 impl Foo {}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo {}
+    }
+}
 impl Packet for Foo {
     fn encoded_len(&self) -> usize {
         0

--- a/pdl-compiler/tests/generated/rust/packet_decl_empty_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_empty_little_endian.rs
@@ -23,10 +23,15 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {}
 impl Foo {}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo {}
+    }
+}
 impl Packet for Foo {
     fn encoded_len(&self) -> usize {
         0

--- a/pdl-compiler/tests/generated/rust/packet_decl_fixed_enum_field_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_fixed_enum_field_big_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Enum7 {
-    #[default]
     A = 0x1,
     B = 0x2,
+}
+impl Default for Enum7 {
+    fn default() -> Enum7 {
+        Enum7::A
+    }
 }
 impl TryFrom<u8> for Enum7 {
     type Error = u8;
@@ -90,7 +94,7 @@ impl From<Enum7> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub b: u64,
@@ -98,6 +102,11 @@ pub struct Foo {
 impl Foo {
     pub fn b(&self) -> u64 {
         self.b
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { b: 0 }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_fixed_enum_field_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_fixed_enum_field_little_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Enum7 {
-    #[default]
     A = 0x1,
     B = 0x2,
+}
+impl Default for Enum7 {
+    fn default() -> Enum7 {
+        Enum7::A
+    }
 }
 impl TryFrom<u8> for Enum7 {
     type Error = u8;
@@ -90,7 +94,7 @@ impl From<Enum7> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub b: u64,
@@ -98,6 +102,11 @@ pub struct Foo {
 impl Foo {
     pub fn b(&self) -> u64 {
         self.b
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { b: 0 }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_fixed_scalar_field_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_fixed_scalar_field_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub b: u64,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn b(&self) -> u64 {
         self.b
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { b: 0 }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_fixed_scalar_field_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_fixed_scalar_field_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub b: u64,
@@ -31,6 +31,11 @@ pub struct Foo {
 impl Foo {
     pub fn b(&self) -> u64 {
         self.b
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { b: 0 }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_grand_children_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_grand_children_big_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
 pub enum Enum16 {
-    #[default]
     A = 0x1,
     B = 0x2,
+}
+impl Default for Enum16 {
+    fn default() -> Enum16 {
+        Enum16::A
+    }
 }
 impl TryFrom<u16> for Enum16 {
     type Error = u16;
@@ -75,7 +79,7 @@ impl From<Enum16> for u64 {
         u16::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parent {
     pub foo: Enum16,
@@ -114,6 +118,16 @@ impl Parent {
     }
     pub fn baz(&self) -> Enum16 {
         self.baz
+    }
+}
+impl Default for Parent {
+    fn default() -> Parent {
+        Parent {
+            foo: Default::default(),
+            bar: Default::default(),
+            baz: Default::default(),
+            payload: vec![],
+        }
     }
 }
 impl Packet for Parent {
@@ -199,7 +213,7 @@ impl Packet for Parent {
         Ok((Self { payload, foo, bar, baz }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Child {
     pub quux: Enum16,
@@ -314,6 +328,16 @@ impl Child {
         Enum16::A
     }
 }
+impl Default for Child {
+    fn default() -> Child {
+        Child {
+            quux: Default::default(),
+            bar: Default::default(),
+            baz: Default::default(),
+            payload: vec![],
+        }
+    }
+}
 impl Packet for Child {
     fn encoded_len(&self) -> usize {
         9 + self.payload.len()
@@ -340,7 +364,7 @@ impl Packet for Child {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrandChild {
     pub baz: Enum16,
@@ -463,6 +487,14 @@ impl GrandChild {
         Enum16::A
     }
 }
+impl Default for GrandChild {
+    fn default() -> GrandChild {
+        GrandChild {
+            baz: Default::default(),
+            payload: vec![],
+        }
+    }
+}
 impl Packet for GrandChild {
     fn encoded_len(&self) -> usize {
         9 + self.payload.len()
@@ -490,7 +522,7 @@ impl Packet for GrandChild {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrandGrandChild {
     pub payload: Vec<u8>,
@@ -609,6 +641,11 @@ impl GrandGrandChild {
     }
     pub fn baz(&self) -> Enum16 {
         Enum16::A
+    }
+}
+impl Default for GrandGrandChild {
+    fn default() -> GrandGrandChild {
+        GrandGrandChild { payload: vec![] }
     }
 }
 impl Packet for GrandGrandChild {

--- a/pdl-compiler/tests/generated/rust/packet_decl_grand_children_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_grand_children_little_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
 pub enum Enum16 {
-    #[default]
     A = 0x1,
     B = 0x2,
+}
+impl Default for Enum16 {
+    fn default() -> Enum16 {
+        Enum16::A
+    }
 }
 impl TryFrom<u16> for Enum16 {
     type Error = u16;
@@ -75,7 +79,7 @@ impl From<Enum16> for u64 {
         u16::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parent {
     pub foo: Enum16,
@@ -114,6 +118,16 @@ impl Parent {
     }
     pub fn baz(&self) -> Enum16 {
         self.baz
+    }
+}
+impl Default for Parent {
+    fn default() -> Parent {
+        Parent {
+            foo: Default::default(),
+            bar: Default::default(),
+            baz: Default::default(),
+            payload: vec![],
+        }
     }
 }
 impl Packet for Parent {
@@ -199,7 +213,7 @@ impl Packet for Parent {
         Ok((Self { payload, foo, bar, baz }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Child {
     pub quux: Enum16,
@@ -314,6 +328,16 @@ impl Child {
         Enum16::A
     }
 }
+impl Default for Child {
+    fn default() -> Child {
+        Child {
+            quux: Default::default(),
+            bar: Default::default(),
+            baz: Default::default(),
+            payload: vec![],
+        }
+    }
+}
 impl Packet for Child {
     fn encoded_len(&self) -> usize {
         9 + self.payload.len()
@@ -340,7 +364,7 @@ impl Packet for Child {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrandChild {
     pub baz: Enum16,
@@ -463,6 +487,14 @@ impl GrandChild {
         Enum16::A
     }
 }
+impl Default for GrandChild {
+    fn default() -> GrandChild {
+        GrandChild {
+            baz: Default::default(),
+            payload: vec![],
+        }
+    }
+}
 impl Packet for GrandChild {
     fn encoded_len(&self) -> usize {
         9 + self.payload.len()
@@ -490,7 +522,7 @@ impl Packet for GrandChild {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrandGrandChild {
     pub payload: Vec<u8>,
@@ -609,6 +641,11 @@ impl GrandGrandChild {
     }
     pub fn baz(&self) -> Enum16 {
         Enum16::A
+    }
+}
+impl Default for GrandGrandChild {
+    fn default() -> GrandGrandChild {
+        GrandGrandChild { payload: vec![] }
     }
 }
 impl Packet for GrandGrandChild {

--- a/pdl-compiler/tests/generated/rust/packet_decl_mask_scalar_value_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_mask_scalar_value_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,
@@ -39,6 +39,11 @@ impl Foo {
     }
     pub fn c(&self) -> u8 {
         self.c
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { a: 0, b: 0, c: 0 }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_mask_scalar_value_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_mask_scalar_value_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,
@@ -39,6 +39,11 @@ impl Foo {
     }
     pub fn c(&self) -> u8 {
         self.c
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { a: 0, b: 0, c: 0 }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_mixed_scalars_enums_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_mixed_scalars_enums_big_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Enum7 {
-    #[default]
     A = 0x1,
     B = 0x2,
+}
+impl Default for Enum7 {
+    fn default() -> Enum7 {
+        Enum7::A
+    }
 }
 impl TryFrom<u8> for Enum7 {
     type Error = u8;
@@ -91,13 +95,17 @@ impl From<Enum7> for u64 {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
 pub enum Enum9 {
-    #[default]
     A = 0x1,
     B = 0x2,
+}
+impl Default for Enum9 {
+    fn default() -> Enum9 {
+        Enum9::A
+    }
 }
 impl TryFrom<u16> for Enum9 {
     type Error = u16;
@@ -147,7 +155,7 @@ impl From<Enum9> for u64 {
         u16::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: Enum7,
@@ -167,6 +175,16 @@ impl Foo {
     }
     pub fn w(&self) -> u8 {
         self.w
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo {
+            x: Default::default(),
+            y: 0,
+            z: Default::default(),
+            w: 0,
+        }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_mixed_scalars_enums_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_mixed_scalars_enums_little_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Enum7 {
-    #[default]
     A = 0x1,
     B = 0x2,
+}
+impl Default for Enum7 {
+    fn default() -> Enum7 {
+        Enum7::A
+    }
 }
 impl TryFrom<u8> for Enum7 {
     type Error = u8;
@@ -91,13 +95,17 @@ impl From<Enum7> for u64 {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
 pub enum Enum9 {
-    #[default]
     A = 0x1,
     B = 0x2,
+}
+impl Default for Enum9 {
+    fn default() -> Enum9 {
+        Enum9::A
+    }
 }
 impl TryFrom<u16> for Enum9 {
     type Error = u16;
@@ -147,7 +155,7 @@ impl From<Enum9> for u64 {
         u16::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: Enum7,
@@ -167,6 +175,16 @@ impl Foo {
     }
     pub fn w(&self) -> u8 {
         self.w
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo {
+            x: Default::default(),
+            y: 0,
+            z: Default::default(),
+            w: 0,
+        }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_parent_with_alias_child_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_parent_with_alias_child_big_endian.rs
@@ -24,14 +24,18 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Enum8 {
-    #[default]
     A = 0x0,
     B = 0x1,
     C = 0x2,
+}
+impl Default for Enum8 {
+    fn default() -> Enum8 {
+        Enum8::A
+    }
 }
 impl TryFrom<u8> for Enum8 {
     type Error = u8;
@@ -88,7 +92,7 @@ impl From<Enum8> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parent {
     pub v: Enum8,
@@ -117,6 +121,14 @@ impl Parent {
     }
     pub fn v(&self) -> Enum8 {
         self.v
+    }
+}
+impl Default for Parent {
+    fn default() -> Parent {
+        Parent {
+            v: Default::default(),
+            payload: vec![],
+        }
     }
 }
 impl Packet for Parent {
@@ -148,7 +160,7 @@ impl Packet for Parent {
         Ok((Self { payload, v }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AliasChild {
     pub v: Enum8,
@@ -219,6 +231,14 @@ impl AliasChild {
         self.v
     }
 }
+impl Default for AliasChild {
+    fn default() -> AliasChild {
+        AliasChild {
+            v: Default::default(),
+            payload: vec![],
+        }
+    }
+}
 impl Packet for AliasChild {
     fn encoded_len(&self) -> usize {
         1 + self.payload.len()
@@ -234,7 +254,7 @@ impl Packet for AliasChild {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NormalChild {}
 impl TryFrom<&NormalChild> for Parent {
@@ -283,6 +303,11 @@ impl NormalChild {
         Enum8::A
     }
 }
+impl Default for NormalChild {
+    fn default() -> NormalChild {
+        NormalChild {}
+    }
+}
 impl Packet for NormalChild {
     fn encoded_len(&self) -> usize {
         1
@@ -298,7 +323,7 @@ impl Packet for NormalChild {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NormalGrandChild1 {}
 impl TryFrom<&NormalGrandChild1> for AliasChild {
@@ -371,6 +396,11 @@ impl NormalGrandChild1 {
         Enum8::B
     }
 }
+impl Default for NormalGrandChild1 {
+    fn default() -> NormalGrandChild1 {
+        NormalGrandChild1 {}
+    }
+}
 impl Packet for NormalGrandChild1 {
     fn encoded_len(&self) -> usize {
         1
@@ -386,7 +416,7 @@ impl Packet for NormalGrandChild1 {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NormalGrandChild2 {
     pub payload: Vec<u8>,
@@ -469,6 +499,13 @@ impl NormalGrandChild2 {
     }
     pub fn v(&self) -> Enum8 {
         Enum8::C
+    }
+}
+impl Default for NormalGrandChild2 {
+    fn default() -> NormalGrandChild2 {
+        NormalGrandChild2 {
+            payload: vec![],
+        }
     }
 }
 impl Packet for NormalGrandChild2 {

--- a/pdl-compiler/tests/generated/rust/packet_decl_parent_with_alias_child_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_parent_with_alias_child_little_endian.rs
@@ -24,14 +24,18 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Enum8 {
-    #[default]
     A = 0x0,
     B = 0x1,
     C = 0x2,
+}
+impl Default for Enum8 {
+    fn default() -> Enum8 {
+        Enum8::A
+    }
 }
 impl TryFrom<u8> for Enum8 {
     type Error = u8;
@@ -88,7 +92,7 @@ impl From<Enum8> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parent {
     pub v: Enum8,
@@ -117,6 +121,14 @@ impl Parent {
     }
     pub fn v(&self) -> Enum8 {
         self.v
+    }
+}
+impl Default for Parent {
+    fn default() -> Parent {
+        Parent {
+            v: Default::default(),
+            payload: vec![],
+        }
     }
 }
 impl Packet for Parent {
@@ -148,7 +160,7 @@ impl Packet for Parent {
         Ok((Self { payload, v }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AliasChild {
     pub v: Enum8,
@@ -219,6 +231,14 @@ impl AliasChild {
         self.v
     }
 }
+impl Default for AliasChild {
+    fn default() -> AliasChild {
+        AliasChild {
+            v: Default::default(),
+            payload: vec![],
+        }
+    }
+}
 impl Packet for AliasChild {
     fn encoded_len(&self) -> usize {
         1 + self.payload.len()
@@ -234,7 +254,7 @@ impl Packet for AliasChild {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NormalChild {}
 impl TryFrom<&NormalChild> for Parent {
@@ -283,6 +303,11 @@ impl NormalChild {
         Enum8::A
     }
 }
+impl Default for NormalChild {
+    fn default() -> NormalChild {
+        NormalChild {}
+    }
+}
 impl Packet for NormalChild {
     fn encoded_len(&self) -> usize {
         1
@@ -298,7 +323,7 @@ impl Packet for NormalChild {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NormalGrandChild1 {}
 impl TryFrom<&NormalGrandChild1> for AliasChild {
@@ -371,6 +396,11 @@ impl NormalGrandChild1 {
         Enum8::B
     }
 }
+impl Default for NormalGrandChild1 {
+    fn default() -> NormalGrandChild1 {
+        NormalGrandChild1 {}
+    }
+}
 impl Packet for NormalGrandChild1 {
     fn encoded_len(&self) -> usize {
         1
@@ -386,7 +416,7 @@ impl Packet for NormalGrandChild1 {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NormalGrandChild2 {
     pub payload: Vec<u8>,
@@ -469,6 +499,13 @@ impl NormalGrandChild2 {
     }
     pub fn v(&self) -> Enum8 {
         Enum8::C
+    }
+}
+impl Default for NormalGrandChild2 {
+    fn default() -> NormalGrandChild2 {
+        NormalGrandChild2 {
+            payload: vec![],
+        }
     }
 }
 impl Packet for NormalGrandChild2 {

--- a/pdl-compiler/tests/generated/rust/packet_decl_parent_with_no_payload_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_parent_with_no_payload_big_endian.rs
@@ -24,12 +24,16 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Enum8 {
-    #[default]
     A = 0x0,
+}
+impl Default for Enum8 {
+    fn default() -> Enum8 {
+        Enum8::A
+    }
 }
 impl TryFrom<u8> for Enum8 {
     type Error = u8;
@@ -82,7 +86,7 @@ impl From<Enum8> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parent {
     pub v: Enum8,
@@ -105,6 +109,11 @@ impl Parent {
     }
     pub fn v(&self) -> Enum8 {
         self.v
+    }
+}
+impl Default for Parent {
+    fn default() -> Parent {
+        Parent { v: Default::default() }
     }
 }
 impl Packet for Parent {
@@ -133,7 +142,7 @@ impl Packet for Parent {
         Ok((Self { v }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Child {}
 impl From<&Child> for Parent {
@@ -175,6 +184,11 @@ impl Child {
     }
     pub fn v(&self) -> Enum8 {
         Enum8::A
+    }
+}
+impl Default for Child {
+    fn default() -> Child {
+        Child {}
     }
 }
 impl Packet for Child {

--- a/pdl-compiler/tests/generated/rust/packet_decl_parent_with_no_payload_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_parent_with_no_payload_little_endian.rs
@@ -24,12 +24,16 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
 pub enum Enum8 {
-    #[default]
     A = 0x0,
+}
+impl Default for Enum8 {
+    fn default() -> Enum8 {
+        Enum8::A
+    }
 }
 impl TryFrom<u8> for Enum8 {
     type Error = u8;
@@ -82,7 +86,7 @@ impl From<Enum8> for u64 {
         u8::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parent {
     pub v: Enum8,
@@ -105,6 +109,11 @@ impl Parent {
     }
     pub fn v(&self) -> Enum8 {
         self.v
+    }
+}
+impl Default for Parent {
+    fn default() -> Parent {
+        Parent { v: Default::default() }
     }
 }
 impl Packet for Parent {
@@ -133,7 +142,7 @@ impl Packet for Parent {
         Ok((Self { v }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Child {}
 impl From<&Child> for Parent {
@@ -175,6 +184,11 @@ impl Child {
     }
     pub fn v(&self) -> Enum8 {
         Enum8::A
+    }
+}
+impl Default for Child {
+    fn default() -> Child {
+        Child {}
     }
 }
 impl Packet for Child {

--- a/pdl-compiler/tests/generated/rust/packet_decl_payload_field_unknown_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_payload_field_unknown_size_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u32,
@@ -35,6 +35,11 @@ impl Foo {
     }
     pub fn a(&self) -> u32 {
         self.a
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { a: 0, payload: vec![] }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_payload_field_unknown_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_payload_field_unknown_size_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u32,
@@ -35,6 +35,11 @@ impl Foo {
     }
     pub fn a(&self) -> u32 {
         self.a
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { a: 0, payload: vec![] }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_payload_field_unknown_size_terminal_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_payload_field_unknown_size_terminal_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u32,
@@ -35,6 +35,11 @@ impl Foo {
     }
     pub fn a(&self) -> u32 {
         self.a
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { a: 0, payload: vec![] }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_payload_field_unknown_size_terminal_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_payload_field_unknown_size_terminal_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u32,
@@ -35,6 +35,11 @@ impl Foo {
     }
     pub fn a(&self) -> u32 {
         self.a
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { a: 0, payload: vec![] }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_payload_field_variable_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_payload_field_variable_size_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,
@@ -39,6 +39,11 @@ impl Foo {
     }
     pub fn b(&self) -> u16 {
         self.b
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { a: 0, b: 0, payload: vec![] }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_payload_field_variable_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_payload_field_variable_size_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,
@@ -39,6 +39,11 @@ impl Foo {
     }
     pub fn b(&self) -> u16 {
         self.b
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { a: 0, b: 0, payload: vec![] }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_reserved_field_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_reserved_field_big_endian.rs
@@ -23,10 +23,15 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {}
 impl Foo {}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo {}
+    }
+}
 impl Packet for Foo {
     fn encoded_len(&self) -> usize {
         5

--- a/pdl-compiler/tests/generated/rust/packet_decl_reserved_field_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_reserved_field_little_endian.rs
@@ -23,10 +23,15 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {}
 impl Foo {}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo {}
+    }
+}
 impl Packet for Foo {
     fn encoded_len(&self) -> usize {
         5

--- a/pdl-compiler/tests/generated/rust/packet_decl_simple_scalars_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_simple_scalars_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: u8,
@@ -39,6 +39,11 @@ impl Foo {
     }
     pub fn z(&self) -> u32 {
         self.z
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { x: 0, y: 0, z: 0 }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/packet_decl_simple_scalars_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_simple_scalars_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub x: u8,
@@ -39,6 +39,11 @@ impl Foo {
     }
     pub fn z(&self) -> u32 {
         self.z
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo { x: 0, y: 0, z: 0 }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/payload_with_size_modifier_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/payload_with_size_modifier_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Test {
     pub payload: Vec<u8>,
@@ -31,6 +31,11 @@ pub struct Test {
 impl Test {
     pub fn payload(&self) -> &[u8] {
         &self.payload
+    }
+}
+impl Default for Test {
+    fn default() -> Test {
+        Test { payload: vec![] }
     }
 }
 impl Packet for Test {

--- a/pdl-compiler/tests/generated/rust/payload_with_size_modifier_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/payload_with_size_modifier_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Test {
     pub payload: Vec<u8>,
@@ -31,6 +31,11 @@ pub struct Test {
 impl Test {
     pub fn payload(&self) -> &[u8] {
         &self.payload
+    }
+}
+impl Default for Test {
+    fn default() -> Test {
+        Test { payload: vec![] }
     }
 }
 impl Packet for Test {

--- a/pdl-compiler/tests/generated/rust/reserved_identifier_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/reserved_identifier_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Test {
     pub r#type: u8,
@@ -31,6 +31,11 @@ pub struct Test {
 impl Test {
     pub fn r#type(&self) -> u8 {
         self.r#type
+    }
+}
+impl Default for Test {
+    fn default() -> Test {
+        Test { r#type: 0 }
     }
 }
 impl Packet for Test {

--- a/pdl-compiler/tests/generated/rust/reserved_identifier_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/reserved_identifier_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Test {
     pub r#type: u8,
@@ -31,6 +31,11 @@ pub struct Test {
 impl Test {
     pub fn r#type(&self) -> u8 {
         self.r#type
+    }
+}
+impl Default for Test {
+    fn default() -> Test {
+        Test { r#type: 0 }
     }
 }
 impl Packet for Test {

--- a/pdl-compiler/tests/generated/rust/struct_decl_child_structs_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/struct_decl_child_structs_big_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
 pub enum Enum16 {
-    #[default]
     A = 0x1,
     B = 0x2,
+}
+impl Default for Enum16 {
+    fn default() -> Enum16 {
+        Enum16::A
+    }
 }
 impl TryFrom<u16> for Enum16 {
     type Error = u16;
@@ -75,7 +79,7 @@ impl From<Enum16> for u64 {
         u16::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,
@@ -108,6 +112,15 @@ impl Foo {
     }
     pub fn b(&self) -> Enum16 {
         self.b
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo {
+            a: 0,
+            b: Default::default(),
+            payload: vec![],
+        }
     }
 }
 impl Packet for Foo {
@@ -173,7 +186,7 @@ impl Packet for Foo {
         Ok((Self { payload, a, b }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: u8,
@@ -248,6 +261,11 @@ impl Bar {
         100
     }
 }
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar { x: 0, b: Default::default() }
+    }
+}
 impl Packet for Bar {
     fn encoded_len(&self) -> usize {
         5
@@ -273,7 +291,7 @@ impl Packet for Bar {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Baz {
     pub y: u16,
@@ -346,6 +364,11 @@ impl Baz {
     }
     pub fn b(&self) -> Enum16 {
         Enum16::B
+    }
+}
+impl Default for Baz {
+    fn default() -> Baz {
+        Baz { y: 0, a: 0 }
     }
 }
 impl Packet for Baz {

--- a/pdl-compiler/tests/generated/rust/struct_decl_child_structs_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/struct_decl_child_structs_little_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
 pub enum Enum16 {
-    #[default]
     A = 0x1,
     B = 0x2,
+}
+impl Default for Enum16 {
+    fn default() -> Enum16 {
+        Enum16::A
+    }
 }
 impl TryFrom<u16> for Enum16 {
     type Error = u16;
@@ -75,7 +79,7 @@ impl From<Enum16> for u64 {
         u16::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,
@@ -108,6 +112,15 @@ impl Foo {
     }
     pub fn b(&self) -> Enum16 {
         self.b
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo {
+            a: 0,
+            b: Default::default(),
+            payload: vec![],
+        }
     }
 }
 impl Packet for Foo {
@@ -173,7 +186,7 @@ impl Packet for Foo {
         Ok((Self { payload, a, b }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bar {
     pub x: u8,
@@ -248,6 +261,11 @@ impl Bar {
         100
     }
 }
+impl Default for Bar {
+    fn default() -> Bar {
+        Bar { x: 0, b: Default::default() }
+    }
+}
 impl Packet for Bar {
     fn encoded_len(&self) -> usize {
         5
@@ -273,7 +291,7 @@ impl Packet for Bar {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Baz {
     pub y: u16,
@@ -346,6 +364,11 @@ impl Baz {
     }
     pub fn b(&self) -> Enum16 {
         Enum16::B
+    }
+}
+impl Default for Baz {
+    fn default() -> Baz {
+        Baz { y: 0, a: 0 }
     }
 }
 impl Packet for Baz {

--- a/pdl-compiler/tests/generated/rust/struct_decl_complex_scalars_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/struct_decl_complex_scalars_big_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,
@@ -51,6 +51,18 @@ impl Foo {
     }
     pub fn f(&self) -> u8 {
         self.f
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo {
+            a: 0,
+            b: 0,
+            c: 0,
+            d: 0,
+            e: 0,
+            f: 0,
+        }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/struct_decl_complex_scalars_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/struct_decl_complex_scalars_little_endian.rs
@@ -23,7 +23,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
         T::fmt(&self.0, f)
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Foo {
     pub a: u8,
@@ -51,6 +51,18 @@ impl Foo {
     }
     pub fn f(&self) -> u8 {
         self.f
+    }
+}
+impl Default for Foo {
+    fn default() -> Foo {
+        Foo {
+            a: 0,
+            b: 0,
+            c: 0,
+            d: 0,
+            e: 0,
+            f: 0,
+        }
     }
 }
 impl Packet for Foo {

--- a/pdl-compiler/tests/generated/rust/struct_decl_grand_children_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/struct_decl_grand_children_big_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
 pub enum Enum16 {
-    #[default]
     A = 0x1,
     B = 0x2,
+}
+impl Default for Enum16 {
+    fn default() -> Enum16 {
+        Enum16::A
+    }
 }
 impl TryFrom<u16> for Enum16 {
     type Error = u16;
@@ -75,7 +79,7 @@ impl From<Enum16> for u64 {
         u16::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parent {
     pub foo: Enum16,
@@ -114,6 +118,16 @@ impl Parent {
     }
     pub fn baz(&self) -> Enum16 {
         self.baz
+    }
+}
+impl Default for Parent {
+    fn default() -> Parent {
+        Parent {
+            foo: Default::default(),
+            bar: Default::default(),
+            baz: Default::default(),
+            payload: vec![],
+        }
     }
 }
 impl Packet for Parent {
@@ -200,7 +214,7 @@ impl Packet for Parent {
         Ok((Self { payload, foo, bar, baz }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Child {
     pub quux: Enum16,
@@ -316,6 +330,16 @@ impl Child {
         Enum16::A
     }
 }
+impl Default for Child {
+    fn default() -> Child {
+        Child {
+            quux: Default::default(),
+            bar: Default::default(),
+            baz: Default::default(),
+            payload: vec![],
+        }
+    }
+}
 impl Packet for Child {
     fn encoded_len(&self) -> usize {
         9 + self.payload.len()
@@ -342,7 +366,7 @@ impl Packet for Child {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrandChild {
     pub baz: Enum16,
@@ -466,6 +490,14 @@ impl GrandChild {
         Enum16::A
     }
 }
+impl Default for GrandChild {
+    fn default() -> GrandChild {
+        GrandChild {
+            baz: Default::default(),
+            payload: vec![],
+        }
+    }
+}
 impl Packet for GrandChild {
     fn encoded_len(&self) -> usize {
         9 + self.payload.len()
@@ -493,7 +525,7 @@ impl Packet for GrandChild {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrandGrandChild {
     pub payload: Vec<u8>,
@@ -613,6 +645,11 @@ impl GrandGrandChild {
     }
     pub fn baz(&self) -> Enum16 {
         Enum16::A
+    }
+}
+impl Default for GrandGrandChild {
+    fn default() -> GrandGrandChild {
+        GrandGrandChild { payload: vec![] }
     }
 }
 impl Packet for GrandGrandChild {

--- a/pdl-compiler/tests/generated/rust/struct_decl_grand_children_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/struct_decl_grand_children_little_endian.rs
@@ -24,13 +24,17 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Private<T> {
     }
 }
 #[repr(u64)]
-#[derive(Default, Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
 pub enum Enum16 {
-    #[default]
     A = 0x1,
     B = 0x2,
+}
+impl Default for Enum16 {
+    fn default() -> Enum16 {
+        Enum16::A
+    }
 }
 impl TryFrom<u16> for Enum16 {
     type Error = u16;
@@ -75,7 +79,7 @@ impl From<Enum16> for u64 {
         u16::from(value) as Self
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Parent {
     pub foo: Enum16,
@@ -114,6 +118,16 @@ impl Parent {
     }
     pub fn baz(&self) -> Enum16 {
         self.baz
+    }
+}
+impl Default for Parent {
+    fn default() -> Parent {
+        Parent {
+            foo: Default::default(),
+            bar: Default::default(),
+            baz: Default::default(),
+            payload: vec![],
+        }
     }
 }
 impl Packet for Parent {
@@ -200,7 +214,7 @@ impl Packet for Parent {
         Ok((Self { payload, foo, bar, baz }, buf))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Child {
     pub quux: Enum16,
@@ -316,6 +330,16 @@ impl Child {
         Enum16::A
     }
 }
+impl Default for Child {
+    fn default() -> Child {
+        Child {
+            quux: Default::default(),
+            bar: Default::default(),
+            baz: Default::default(),
+            payload: vec![],
+        }
+    }
+}
 impl Packet for Child {
     fn encoded_len(&self) -> usize {
         9 + self.payload.len()
@@ -342,7 +366,7 @@ impl Packet for Child {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrandChild {
     pub baz: Enum16,
@@ -466,6 +490,14 @@ impl GrandChild {
         Enum16::A
     }
 }
+impl Default for GrandChild {
+    fn default() -> GrandChild {
+        GrandChild {
+            baz: Default::default(),
+            payload: vec![],
+        }
+    }
+}
 impl Packet for GrandChild {
     fn encoded_len(&self) -> usize {
         9 + self.payload.len()
@@ -493,7 +525,7 @@ impl Packet for GrandChild {
         Ok((packet, trailing_bytes))
     }
 }
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrandGrandChild {
     pub payload: Vec<u8>,
@@ -613,6 +645,11 @@ impl GrandGrandChild {
     }
     pub fn baz(&self) -> Enum16 {
         Enum16::A
+    }
+}
+impl Default for GrandGrandChild {
+    fn default() -> GrandGrandChild {
+        GrandGrandChild { payload: vec![] }
     }
 }
 impl Packet for GrandGrandChild {

--- a/pdl-tests/tests/traits.rs
+++ b/pdl-tests/tests/traits.rs
@@ -1,0 +1,67 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use pdl_derive::pdl_inline;
+
+#[pdl_inline(
+    r#"
+little_endian_packets
+
+enum TestEnum : 8 {
+    A = 1,
+    B = 2,
+    OTHER = ..,
+}
+
+enum TestEnumRanges : 8 {
+    A = 1 .. 10,
+    B = 11 .. 20,
+    OTHER = ..,
+}
+
+struct TestStruct {
+    _count_(a) : 8,
+    a: TestEnum[],
+}
+
+packet TestPacket {
+  a: 8,
+  b: 1,
+  _reserved_ : 7,
+  c: TestEnum,
+  d: 8[40],
+  e: TestStruct,
+  f: 16 if b = 0,
+  _payload_
+}
+"#
+)]
+#[cfg(test)]
+mod default_trait {
+    #[test]
+    fn test() {
+        assert_eq!(TestEnum::default(), TestEnum::A);
+        assert_eq!(TestEnumRanges::default(), TestEnumRanges::try_from(1).unwrap());
+
+        let default_struct = TestStruct::default();
+        assert_eq!(default_struct.a.len(), 0);
+
+        let default_packet = TestPacket::default();
+        assert_eq!(default_packet.a, 0);
+        assert_eq!(default_packet.c, TestEnum::A);
+        assert_eq!(default_packet.d, [0; 40]);
+        assert_eq!(default_packet.e, default_struct);
+        assert_eq!(default_packet.f, None);
+    }
+}


### PR DESCRIPTION
- The Default trait derivation does not support static arrays
  of size greater than 32.
- The first enum tag is not always a value, but can also be
  a range of values. Thus the default value for enums must be
  manually determined as well.
