### PR TITLE
Add #[allow(unused_comparisons)] directive on some generated checks

### DIFF
--- a/pdl-compiler/src/backends/rust/encoder.rs
+++ b/pdl-compiler/src/backends/rust/encoder.rs
@@ -389,7 +389,10 @@ impl Encoder {
                     _ => panic!("Unexpected size field: {field:?}"),
                 };
 
+                // TODO: this check is generated with an allow() directive since the size might
+                // be constant. It should be removed when always true.
                 self.tokens.extend(quote! {
+                    #[allow(unused_comparisons)]
                     if #array_size > #max_value {
                         return Err(EncodeError::SizeOverflow {
                             packet: #packet_name,

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_dynamic_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_dynamic_size_big_endian.rs
@@ -77,6 +77,7 @@ impl Packet for Bar {
     }
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
         let x_size = self.x.iter().map(Packet::encoded_len).sum::<usize>();
+        #[allow(unused_comparisons)]
         if x_size > 0xf {
             return Err(EncodeError::SizeOverflow {
                 packet: "Bar",

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_dynamic_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_element_size_dynamic_size_little_endian.rs
@@ -77,6 +77,7 @@ impl Packet for Bar {
     }
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
         let x_size = self.x.iter().map(Packet::encoded_len).sum::<usize>();
+        #[allow(unused_comparisons)]
         if x_size > 0xf {
             return Err(EncodeError::SizeOverflow {
                 packet: "Bar",

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_size_big_endian.rs
@@ -47,6 +47,7 @@ impl Packet for Foo {
         1 + (self.x.len() * 3)
     }
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        #[allow(unused_comparisons)]
         if (self.x.len() * 3) > 0x1f {
             return Err(EncodeError::SizeOverflow {
                 packet: "Foo",

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_dynamic_size_little_endian.rs
@@ -47,6 +47,7 @@ impl Packet for Foo {
         1 + (self.x.len() * 3)
     }
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        #[allow(unused_comparisons)]
         if (self.x.len() * 3) > 0x1f {
             return Err(EncodeError::SizeOverflow {
                 packet: "Foo",

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_unknown_element_width_dynamic_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_unknown_element_width_dynamic_size_big_endian.rs
@@ -100,6 +100,7 @@ impl Packet for Bar {
     }
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
         let x_size = self.x.iter().map(Packet::encoded_len).sum::<usize>();
+        #[allow(unused_comparisons)]
         if x_size > 0xff_ffff_ffff_usize {
             return Err(EncodeError::SizeOverflow {
                 packet: "Bar",

--- a/pdl-compiler/tests/generated/rust/packet_decl_array_unknown_element_width_dynamic_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_array_unknown_element_width_dynamic_size_little_endian.rs
@@ -100,6 +100,7 @@ impl Packet for Bar {
     }
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
         let x_size = self.x.iter().map(Packet::encoded_len).sum::<usize>();
+        #[allow(unused_comparisons)]
         if x_size > 0xff_ffff_ffff_usize {
             return Err(EncodeError::SizeOverflow {
                 packet: "Bar",

--- a/pdl-compiler/tests/generated/rust/packet_decl_child_packets_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_child_packets_big_endian.rs
@@ -130,6 +130,7 @@ impl Packet for Foo {
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
         buf.put_u8(self.a());
         buf.put_u16(u16::from(self.b()));
+        #[allow(unused_comparisons)]
         if self.payload.len() > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Foo",
@@ -272,6 +273,7 @@ impl Packet for Bar {
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
         buf.put_u8(self.a());
         buf.put_u16(u16::from(self.b()));
+        #[allow(unused_comparisons)]
         if 1 > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Foo",
@@ -377,6 +379,7 @@ impl Packet for Baz {
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
         buf.put_u8(self.a());
         buf.put_u16(u16::from(self.b()));
+        #[allow(unused_comparisons)]
         if 2 > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Foo",

--- a/pdl-compiler/tests/generated/rust/packet_decl_child_packets_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_child_packets_little_endian.rs
@@ -130,6 +130,7 @@ impl Packet for Foo {
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
         buf.put_u8(self.a());
         buf.put_u16_le(u16::from(self.b()));
+        #[allow(unused_comparisons)]
         if self.payload.len() > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Foo",
@@ -272,6 +273,7 @@ impl Packet for Bar {
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
         buf.put_u8(self.a());
         buf.put_u16_le(u16::from(self.b()));
+        #[allow(unused_comparisons)]
         if 1 > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Foo",
@@ -377,6 +379,7 @@ impl Packet for Baz {
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
         buf.put_u8(self.a());
         buf.put_u16_le(u16::from(self.b()));
+        #[allow(unused_comparisons)]
         if 2 > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Foo",

--- a/pdl-compiler/tests/generated/rust/packet_decl_grand_children_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_grand_children_big_endian.rs
@@ -138,6 +138,7 @@ impl Packet for Parent {
         buf.put_u16(u16::from(self.foo()));
         buf.put_u16(u16::from(self.bar()));
         buf.put_u16(u16::from(self.baz()));
+        #[allow(unused_comparisons)]
         if self.payload.len() > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Parent",
@@ -346,6 +347,7 @@ impl Packet for Child {
         buf.put_u16(u16::from(self.foo()));
         buf.put_u16(u16::from(self.bar()));
         buf.put_u16(u16::from(self.baz()));
+        #[allow(unused_comparisons)]
         if 2 + self.payload.len() > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Parent",
@@ -503,6 +505,7 @@ impl Packet for GrandChild {
         buf.put_u16(u16::from(self.foo()));
         buf.put_u16(u16::from(self.bar()));
         buf.put_u16(u16::from(self.baz()));
+        #[allow(unused_comparisons)]
         if 2 + self.payload.len() > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Parent",
@@ -656,6 +659,7 @@ impl Packet for GrandGrandChild {
         buf.put_u16(u16::from(self.foo()));
         buf.put_u16(u16::from(self.bar()));
         buf.put_u16(u16::from(self.baz()));
+        #[allow(unused_comparisons)]
         if 2 + self.payload.len() > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Parent",

--- a/pdl-compiler/tests/generated/rust/packet_decl_grand_children_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_grand_children_little_endian.rs
@@ -138,6 +138,7 @@ impl Packet for Parent {
         buf.put_u16_le(u16::from(self.foo()));
         buf.put_u16_le(u16::from(self.bar()));
         buf.put_u16_le(u16::from(self.baz()));
+        #[allow(unused_comparisons)]
         if self.payload.len() > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Parent",
@@ -346,6 +347,7 @@ impl Packet for Child {
         buf.put_u16_le(u16::from(self.foo()));
         buf.put_u16_le(u16::from(self.bar()));
         buf.put_u16_le(u16::from(self.baz()));
+        #[allow(unused_comparisons)]
         if 2 + self.payload.len() > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Parent",
@@ -503,6 +505,7 @@ impl Packet for GrandChild {
         buf.put_u16_le(u16::from(self.foo()));
         buf.put_u16_le(u16::from(self.bar()));
         buf.put_u16_le(u16::from(self.baz()));
+        #[allow(unused_comparisons)]
         if 2 + self.payload.len() > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Parent",
@@ -656,6 +659,7 @@ impl Packet for GrandGrandChild {
         buf.put_u16_le(u16::from(self.foo()));
         buf.put_u16_le(u16::from(self.bar()));
         buf.put_u16_le(u16::from(self.baz()));
+        #[allow(unused_comparisons)]
         if 2 + self.payload.len() > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Parent",

--- a/pdl-compiler/tests/generated/rust/packet_decl_payload_field_variable_size_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_payload_field_variable_size_big_endian.rs
@@ -52,6 +52,7 @@ impl Packet for Foo {
     }
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
         buf.put_u8(self.a());
+        #[allow(unused_comparisons)]
         if self.payload.len() > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Foo",

--- a/pdl-compiler/tests/generated/rust/packet_decl_payload_field_variable_size_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/packet_decl_payload_field_variable_size_little_endian.rs
@@ -52,6 +52,7 @@ impl Packet for Foo {
     }
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
         buf.put_u8(self.a());
+        #[allow(unused_comparisons)]
         if self.payload.len() > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Foo",

--- a/pdl-compiler/tests/generated/rust/payload_with_size_modifier_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/payload_with_size_modifier_big_endian.rs
@@ -43,6 +43,7 @@ impl Packet for Test {
         1 + self.payload.len()
     }
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        #[allow(unused_comparisons)]
         if (self.payload.len() + 1) > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Test",

--- a/pdl-compiler/tests/generated/rust/payload_with_size_modifier_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/payload_with_size_modifier_little_endian.rs
@@ -43,6 +43,7 @@ impl Packet for Test {
         1 + self.payload.len()
     }
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+        #[allow(unused_comparisons)]
         if (self.payload.len() + 1) > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Test",

--- a/pdl-compiler/tests/generated/rust/struct_decl_child_structs_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/struct_decl_child_structs_big_endian.rs
@@ -130,6 +130,7 @@ impl Packet for Foo {
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
         buf.put_u8(self.a());
         buf.put_u16(u16::from(self.b()));
+        #[allow(unused_comparisons)]
         if self.payload.len() > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Foo",
@@ -273,6 +274,7 @@ impl Packet for Bar {
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
         buf.put_u8(self.a());
         buf.put_u16(u16::from(self.b()));
+        #[allow(unused_comparisons)]
         if 1 > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Foo",
@@ -378,6 +380,7 @@ impl Packet for Baz {
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
         buf.put_u8(self.a());
         buf.put_u16(u16::from(self.b()));
+        #[allow(unused_comparisons)]
         if 2 > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Foo",

--- a/pdl-compiler/tests/generated/rust/struct_decl_child_structs_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/struct_decl_child_structs_little_endian.rs
@@ -130,6 +130,7 @@ impl Packet for Foo {
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
         buf.put_u8(self.a());
         buf.put_u16_le(u16::from(self.b()));
+        #[allow(unused_comparisons)]
         if self.payload.len() > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Foo",
@@ -273,6 +274,7 @@ impl Packet for Bar {
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
         buf.put_u8(self.a());
         buf.put_u16_le(u16::from(self.b()));
+        #[allow(unused_comparisons)]
         if 1 > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Foo",
@@ -378,6 +380,7 @@ impl Packet for Baz {
     fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError> {
         buf.put_u8(self.a());
         buf.put_u16_le(u16::from(self.b()));
+        #[allow(unused_comparisons)]
         if 2 > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Foo",

--- a/pdl-compiler/tests/generated/rust/struct_decl_grand_children_big_endian.rs
+++ b/pdl-compiler/tests/generated/rust/struct_decl_grand_children_big_endian.rs
@@ -138,6 +138,7 @@ impl Packet for Parent {
         buf.put_u16(u16::from(self.foo()));
         buf.put_u16(u16::from(self.bar()));
         buf.put_u16(u16::from(self.baz()));
+        #[allow(unused_comparisons)]
         if self.payload.len() > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Parent",
@@ -348,6 +349,7 @@ impl Packet for Child {
         buf.put_u16(u16::from(self.foo()));
         buf.put_u16(u16::from(self.bar()));
         buf.put_u16(u16::from(self.baz()));
+        #[allow(unused_comparisons)]
         if 2 + self.payload.len() > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Parent",
@@ -506,6 +508,7 @@ impl Packet for GrandChild {
         buf.put_u16(u16::from(self.foo()));
         buf.put_u16(u16::from(self.bar()));
         buf.put_u16(u16::from(self.baz()));
+        #[allow(unused_comparisons)]
         if 2 + self.payload.len() > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Parent",
@@ -660,6 +663,7 @@ impl Packet for GrandGrandChild {
         buf.put_u16(u16::from(self.foo()));
         buf.put_u16(u16::from(self.bar()));
         buf.put_u16(u16::from(self.baz()));
+        #[allow(unused_comparisons)]
         if 2 + self.payload.len() > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Parent",

--- a/pdl-compiler/tests/generated/rust/struct_decl_grand_children_little_endian.rs
+++ b/pdl-compiler/tests/generated/rust/struct_decl_grand_children_little_endian.rs
@@ -138,6 +138,7 @@ impl Packet for Parent {
         buf.put_u16_le(u16::from(self.foo()));
         buf.put_u16_le(u16::from(self.bar()));
         buf.put_u16_le(u16::from(self.baz()));
+        #[allow(unused_comparisons)]
         if self.payload.len() > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Parent",
@@ -348,6 +349,7 @@ impl Packet for Child {
         buf.put_u16_le(u16::from(self.foo()));
         buf.put_u16_le(u16::from(self.bar()));
         buf.put_u16_le(u16::from(self.baz()));
+        #[allow(unused_comparisons)]
         if 2 + self.payload.len() > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Parent",
@@ -506,6 +508,7 @@ impl Packet for GrandChild {
         buf.put_u16_le(u16::from(self.foo()));
         buf.put_u16_le(u16::from(self.bar()));
         buf.put_u16_le(u16::from(self.baz()));
+        #[allow(unused_comparisons)]
         if 2 + self.payload.len() > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Parent",
@@ -660,6 +663,7 @@ impl Packet for GrandGrandChild {
         buf.put_u16_le(u16::from(self.foo()));
         buf.put_u16_le(u16::from(self.bar()));
         buf.put_u16_le(u16::from(self.baz()));
+        #[allow(unused_comparisons)]
         if 2 + self.payload.len() > 0xff {
             return Err(EncodeError::SizeOverflow {
                 packet: "Parent",


### PR DESCRIPTION
Size checks can be always true in the case of payloads
of deterministic size. The directive is added to suppress
lint warnings.
